### PR TITLE
Allow video streams to be optional 

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,9 @@ function Peer (opts) {
     }
   }
 
-  this._setupVideo(opts.stream)
+  if (opts.stream) {
+    this._setupVideo(opts.stream)
+  }
 
   if (opts.initiator) {
     this._setupData({ channel: this._pc.createDataChannel(CHANNEL_NAME) })


### PR DESCRIPTION
For uses of simple-peer library, that do not include video streams, instead of always running the video setup, allow a small verification before proceeding. 
