### PR TITLE
wait a bit before destroying on end

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,11 @@ function Peer (opts) {
     if (self.connected) {
       // When local peer is finished writing, close connection to remote peer.
       // Half open connections are currently not supported.
-      self._destroy()
+      // Wait a bit before destroying so the datachannel flushes.
+      // TODO: does datachannels have a .end() that flushes and closes?
+      setTimeout(function () {
+        self._destroy()
+      }, 100)
     } else {
       // If data channel is not connected when local peer is finished writing, wait until
       // data is flushed to network at "connect" event.


### PR DESCRIPTION
this is a bit of a hack but seems to work in most cases. basically there is a bug right right now where simple-peer will discard data when you call `.end()` this happens because we immediately call `.close()` on the datachannel in the flush event and this seems to forcible destroy the datachannel before it has finished flushing

in the future we should look into better ways of doing this :/