### PR TITLE
opts.wrtc

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,17 @@ function gotMedia (stream) {
 }
 ```
 
-For two-way video, simply pass a `stream` option into both `Peer` constructors. Simple!
+### in node
+
+To use this library in node, pass in `opts.wrtc` as a parameter:
+
+```js
+var SimplePeer = require('simple-peer')
+var wrtc = require('wrtc')
+
+var peer1 = new SimplePeer({ initiator: true, wrtc: wrtc })
+var peer2 = new SimplePeer({ wrtc: wrtc })
+```
 
 ## production apps that use `simple-peer`
 
@@ -137,6 +147,7 @@ The options do the following:
 - `constraints` - custom webrtc video/voice constaints
 - `channelName` - custom webrtc data channel name
 - `trickle` - set to `false` to disable [trickle ICE](http://webrtchacks.com/trickle-ice/) and get a single 'signal' event (slower)
+- `wrtc` - webrtc implementation, should have the same interface as the [wrtc](https://npmjs.com/package/wrtc) package
 
 ### `peer.signal(data)`
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ function gotMedia (stream) {
 }
 ```
 
+For two-way video, simply pass a `stream` option into both `Peer` constructors. Simple!
+
 ### in node
 
 To use this library in node, pass in `opts.wrtc` as a parameter:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "string-to-stream": "^1.0.0",
     "tape": "^4.0.0",
     "uglify-js": "^2.4.15",
+    "wrtc": "0.0.x",
     "zuul": "^2.1.1"
   },
   "homepage": "http://webtorrent.io",
@@ -49,9 +50,6 @@
   ],
   "license": "MIT",
   "main": "index.js",
-  "optionalDependencies": {
-    "wrtc": "0.0.x"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/feross/simple-peer.git"

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,8 +1,9 @@
 var Peer = require('../')
 var test = require('tape')
+var wrtc = typeof window === 'undefined' && require('wrtc')
 
 test('signal event gets emitted', function (t) {
-  var peer = new Peer({ initiator: true })
+  var peer = new Peer({ initiator: true, wrtc: wrtc })
   peer.once('signal', function () {
     t.pass('got signal event')
     peer.destroy()
@@ -11,8 +12,8 @@ test('signal event gets emitted', function (t) {
 })
 
 test('data send/receive text', function (t) {
-  var peer1 = new Peer({ initiator: true })
-  var peer2 = new Peer()
+  var peer1 = new Peer({ initiator: true, wrtc: wrtc })
+  var peer2 = new Peer({ wrtc: wrtc })
 
   var numSignal1 = 0
   peer1.on('signal', function (data) {
@@ -60,8 +61,8 @@ test('data send/receive text', function (t) {
 })
 
 test('disable trickle', function (t) {
-  var peer1 = new Peer({ initiator: true, trickle: false })
-  var peer2 = new Peer({ trickle: false })
+  var peer1 = new Peer({ initiator: true, trickle: false, wrtc: wrtc })
+  var peer2 = new Peer({ trickle: false, wrtc: wrtc })
 
   var numSignal1 = 0
   peer1.on('signal', function (data) {
@@ -109,8 +110,8 @@ test('disable trickle', function (t) {
 })
 
 test('disable trickle (only initiator)', function (t) {
-  var peer1 = new Peer({ initiator: true, trickle: false })
-  var peer2 = new Peer()
+  var peer1 = new Peer({ initiator: true, trickle: false, wrtc: wrtc })
+  var peer2 = new Peer({ wrtc: wrtc })
 
   var numSignal1 = 0
   peer1.on('signal', function (data) {
@@ -158,8 +159,8 @@ test('disable trickle (only initiator)', function (t) {
 })
 
 test('disable trickle (only receiver)', function (t) {
-  var peer1 = new Peer({ initiator: true })
-  var peer2 = new Peer({ trickle: false })
+  var peer1 = new Peer({ initiator: true, wrtc: wrtc })
+  var peer2 = new Peer({ trickle: false, wrtc: wrtc })
 
   var numSignal1 = 0
   peer1.on('signal', function (data) {

--- a/test/binary.js
+++ b/test/binary.js
@@ -1,9 +1,10 @@
 var Peer = require('../')
 var test = require('tape')
+var wrtc = typeof window === 'undefined' && require('wrtc')
 
 test('data send/receive Uint8Array', function (t) {
-  var peer1 = new Peer({ initiator: true })
-  var peer2 = new Peer()
+  var peer1 = new Peer({ initiator: true, wrtc: wrtc })
+  var peer2 = new Peer({ wrtc: wrtc })
   peer1.on('signal', function (data) {
     peer2.signal(data)
   })
@@ -41,8 +42,8 @@ test('data send/receive Uint8Array', function (t) {
 })
 
 test('data send/receive Buffer', function (t) {
-  var peer1 = new Peer({ initiator: true })
-  var peer2 = new Peer()
+  var peer1 = new Peer({ initiator: true, wrtc: wrtc })
+  var peer2 = new Peer({ wrtc: wrtc })
   peer1.on('signal', function (data) {
     peer2.signal(data)
   })
@@ -81,8 +82,8 @@ test('data send/receive Buffer', function (t) {
 
 // TODO: re-enable when Chrome supports channel.send(Blob)
 // test('data send/receive Blob', function (t) {
-//   var peer1 = new Peer({ initiator: true })
-//   var peer2 = new Peer()
+//   var peer1 = new Peer({ initiator: true, wrtc: wrtc })
+//   var peer2 = new Peer({ wrtc: wrtc })
 //   peer1.on('signal', function (data) {
 //     peer2.signal(data)
 //   })
@@ -120,8 +121,8 @@ test('data send/receive Buffer', function (t) {
 // })
 
 test('data send/receive ArrayBuffer', function (t) {
-  var peer1 = new Peer({ initiator: true })
-  var peer2 = new Peer()
+  var peer1 = new Peer({ initiator: true, wrtc: wrtc })
+  var peer2 = new Peer({ wrtc: wrtc })
   peer1.on('signal', function (data) {
     peer2.signal(data)
   })

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,12 +1,13 @@
 var str = require('string-to-stream')
 var Peer = require('../')
 var test = require('tape')
+var wrtc = typeof window === 'undefined' && require('wrtc')
 
 test('duplex stream: send data before "connect" event', function (t) {
   t.plan(9)
 
-  var peer1 = new Peer({ initiator: true })
-  var peer2 = new Peer()
+  var peer1 = new Peer({ initiator: true, wrtc: wrtc })
+  var peer2 = new Peer({ wrtc: wrtc })
   peer1.on('signal', function (data) { peer2.signal(data) })
   peer2.on('signal', function (data) { peer1.signal(data) })
 
@@ -40,8 +41,8 @@ test('duplex stream: send data before "connect" event', function (t) {
 test('duplex stream: send data one-way', function (t) {
   t.plan(9)
 
-  var peer1 = new Peer({ initiator: true })
-  var peer2 = new Peer()
+  var peer1 = new Peer({ initiator: true, wrtc: wrtc })
+  var peer2 = new Peer({ wrtc: wrtc })
   peer1.on('signal', function (data) { peer2.signal(data) })
   peer2.on('signal', function (data) { peer1.signal(data) })
   peer1.on('connect', tryTest)


### PR DESCRIPTION
This pull request fixes #14 by removing the hardly-optional-dependency on wrtc, which creates a lot of build and installation headaches for whipping up a simple webrtc app that doesn't even use node. Out of 4 people trying to build a webrtc app with simple-peer last thursday at sudoroom, nobody could get simple-peer to successfully install.

Instead, with this patch you can pass `opts.wrtc` as a parameter in node. In the browser you will get the detected version like before but you can also pass in a custom `opts.wrtc` implementation in the browser too.

The interface changes slightly, so this is a breaking change, but the changes are relatively minor and only apply in node:

```js
var SimplePeer = require('simple-peer')
var wrtc = require('wrtc')

var peer1 = new SimplePeer({ initiator: true, wrtc: wrtc })
var peer2 = new SimplePeer({ wrtc: wrtc })
```

I think the slight extra penalty in API is more than made up for with the gains in installation issues. Plus, by passing in wrtc as an option, the version of wrtc can be versioned separately from simple-peer. This means bugs can be fixed upstream without updating simple-peer and simple-peer can be upgraded while still using an older version of wrtc that is known to work on a platform. And once there is a lighter-weight version of wrtc available, it will be easy to swap it in via `opts.wrtc`.