### PR TITLE
Cache received ice candidates if setting remote description has not c…

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ function Peer (opts) {
   self._channelReady = false
   self._iceComplete = false // ice candidate trickle done (got null candidate)
   self._channel = null
+  self._pendingCandidates = [];
 
   self._chunk = null
   self._cb = null
@@ -157,13 +158,24 @@ Peer.prototype.signal = function (data) {
     self._pc.setRemoteDescription(new (self._wrtc.RTCSessionDescription)(data), function () {
       if (self.destroyed) return
       if (self._pc.remoteDescription.type === 'offer') self._createAnswer()
+
+      self._pendingCandidates.forEach(function(c){
+        self._pc.addIceCandidate(
+	  new (self._wrtc.RTCIceCandidate)(c), noop, self._onError.bind(self)
+        );
+      });
+      self._pendingCandidates = [];
     }, self._onError.bind(self))
   }
   if (data.candidate) {
     try {
-      self._pc.addIceCandidate(
-        new (self._wrtc.RTCIceCandidate)(data.candidate), noop, self._onError.bind(self)
-      )
+      if(self._pc.remoteDescription === null){
+        self._pendingCandidates.push(data.candidate);
+      } else {
+        self._pc.addIceCandidate(
+          new (self._wrtc.RTCIceCandidate)(data.candidate), noop, self._onError.bind(self)
+        )
+      }
     } catch (err) {
       self._destroy(new Error('error adding candidate: ' + err.message))
     }


### PR DESCRIPTION
As the addIceCandidate call completes asynchronously it happens from time to time that ICE candidates are received from the remote side, but the remote description is not set (yet!).

Observed in NodeJS with wrtc. I have not tested if the problem also occurs in the browser.