### PR TITLE
Fix destroy error

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,11 @@ etc.), `ArrayBuffer`, or `Blob` (in browsers that support it).
 Note: If this method is called before the `peer.on('connect')` event has fired, then data
 will be buffered.
 
-### `peer.destroy([onclose])`
+### `peer.destroy([err], [onclose])`
 
 Destroy and cleanup this peer connection.
 
-If the optional `onclose` parameter is passed, then it will be registered as a listener on the 'close' event.
+The optional `err` parameter will be used to invoke 'error' event listeners, while the optional `onclose` parameter will register a listener on the 'close' event.
 
 ### `Peer.WEBRTC_SUPPORT`
 

--- a/index.js
+++ b/index.js
@@ -198,9 +198,9 @@ Peer.prototype.send = function (chunk) {
   self._debug('write: %d bytes', len)
 }
 
-Peer.prototype.destroy = function (onclose) {
+Peer.prototype.destroy = function (err, onclose) {
   var self = this
-  self._destroy(null, onclose)
+  self._destroy(err, onclose)
 }
 
 Peer.prototype._destroy = function (err, onclose) {

--- a/index.js
+++ b/index.js
@@ -109,6 +109,10 @@ function Peer (opts) {
       })
     }
   })
+
+  self.on('error', function (err) {
+    self._debug('error %s', err.message || err)
+  })
 }
 
 Peer.WEBRTC_SUPPORT = !!getBrowserRTC()


### PR DESCRIPTION
Currently the public `.destroy` signature doesn't match with the internal `._destroy`. As other libraries like [bittorrent-swarm](https://github.com/feross/bittorrent-swarm/blob/master/index.js#L133) are using the CSP interface and pass an error as the first argument, descendants of EventEmitter complain about the invalid parameter.

