### PR TITLE
[WIP] Implementation of .renegotiate and .negotiate API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false
+
+[COMMIT_EDITMSG]
+max_line_length = 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-img/
 node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 img/
 node_modules/
+.*
+*.log

--- a/test/renegotiation.js
+++ b/test/renegotiation.js
@@ -1,0 +1,86 @@
+var common = require('./common')
+var Peer = require('../')
+var test = require('tape')
+
+var getUserMedia = typeof navigator !== 'undefined' && (
+  navigator.webkitGetUserMedia && function ( options, fulfill, reject ) {
+    // Create a fake stream
+    var stream = new webkitMediaStream()
+    Object.defineProperty(stream, 'active', { value: true })
+
+    fulfill( stream )
+  } ||
+  navigator.mozGetUserMedia && function ( options, fulfill, reject ) {
+    options.fake = true
+    navigator.mozGetUserMedia( options, fulfill, reject )
+  } ||
+  navigator.getUserMedia
+)
+
+var mediaStream
+test('fetch fake media stream', function (t) {
+  getUserMedia({ video: true, audio: true },
+    function ( stream ) {
+      mediaStream = stream
+      t.end()
+    },
+    function ( err ) {
+      t.fail( 'error fetching mediaStream' )
+      t.end()
+    }
+  )
+})
+
+var config
+test('get config', function (t) {
+  common.getConfig(function (err, _config) {
+    if (err) return t.fail(err)
+    config = _config
+    t.end()
+  })
+})
+
+var debug = console.log.bind( console )
+
+test('renegotiation with fake stream', function (t) {
+  var peer1 = new Peer({ config: config, wrtc: common.wrtc, trickle: false, initiator: true })
+  var peer2 = new Peer({ config: config, wrtc: common.wrtc, trickle: false })
+
+  peer1.on('signal', function (data) {
+    t.pass( 'signal from peer1' )
+    peer2.signal(data)
+  })
+
+  peer2.on('signal', function (data) {
+    t.pass( 'signal from peer2' )
+    peer1.signal(data)
+  })
+
+  peer1.once( 'connect', bothConnected )
+  peer2.once( 'connect', bothConnected )
+
+  function bothConnected () {
+    t.pass( 'peer connected' )
+
+    if (
+      ! peer1.connected ||
+      ! peer2.connected
+    ) return false
+
+    t.pass( 'both connected' )
+
+    peer1.once( 'negotiated', renegotiated )
+
+    // Inject stream on peer1
+    peer1.addStream( mediaStream )
+  }
+
+  function renegotiated () {
+    t.pass( 'negotiated emited' )
+
+    t.ok( peer1.connected )
+    t.ok( peer2.connected )
+    t.end()
+  }
+
+})


### PR DESCRIPTION
- [x] Add `.renegotiate`
- [x] Add `.negotiate`
- [x] Add `negotiate` event
- [x] Add `.addStream`
- [ ] Add `.removeStream`
- [ ] Add `.addDataStream` - have a question if we should allow multiple datastreams
- [ ] Add `.removeDataStream`
- [x] Add tests where a fake MediaStream instance is added into peers post their first established connection
  - [x] Added `.editorconfig`
  - [x] Added `node_modules/` to `.gitignore` and `.npmignore`

Current stage:
- firefox is giving an error because of differences on sdp both m lines, unfortunately I can only finish this implementation Monday

Related issues:
- #68
- #50 
