### PR TITLE
offerConstraints fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function Peer (opts) {
   self.channelConfig = opts.channelConfig || Peer.channelConfig
   self.config = opts.config || Peer.config
   self.constraints = opts.constraints || Peer.constraints
-  self.offerConstraints = opts.offerConstraints
+  self.offerConstraints = opts.offerConstraints || {}
   self.answerConstraints = opts.answerConstraints
   self.reconnectTimer = opts.reconnectTimer || false
   self.sdpTransform = opts.sdpTransform || function (sdp) { return sdp }


### PR DESCRIPTION
When I try to run simple-peer on node I am getting this error:

```
/Users/../node_modules/wrtc/lib/peerconnection.js:216
      throw new Error('Invalid call to createOffer - function must either have prototype'
      ^

Error: Invalid call to createOffer - function must either have prototype ([config]) or (successCallback, failureCallback, [config]).
    at RTCPeerConnection.createOffer (/Users/../node_modules/wrtc/lib/peerconnection.js:216:13)
    at Peer._createOffer (/Users/../node_modules/simple-peer/index.js:322:12)
    at RTCPeerConnection.<anonymous> (/Users/../node_modules/simple-peer/index.js:96:12)
    at RTCPeerConnection.f [as onnegotiationneeded] (/Users/../node_modules/once/once.js:17:25)
    at new Peer (/Users/../node_modules/simple-peer/index.js:101:16)
    at Object.<anonymous> (/Users/../seed.js:61:9)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
```

Using initializer:
```
var peer = new SimplePeer({ initiator: true, wrtc: wrtc })
```


It appears a current fix is to explicitly set `offerConstraints` in the options to a new peer like this:
```
var peer = new SimplePeer({ initiator: true, wrtc: wrtc, offerConstraints: {} })
```

This pull request would fix this.


OS: Mac OS X El Capitan 10.11.6
simple-peer: v6.0.5
wrtc: v0.0.61
node: v6.4.0
npm: v3.10.3