### PR TITLE
destroy with error on iceConnectionState failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,7 +399,7 @@ Peer.prototype._onIceConnectionStateChange = function () {
     }
   }
   if (iceConnectionState === 'failed') {
-    self._destroy()
+    self._destroy(new Error('Ice connection failed.'))
   }
   if (iceConnectionState === 'closed') {
     self._destroy()


### PR DESCRIPTION
Added a descriptive error for the case where `iceConnectionState` became 'failed'.'

I was consuming this module upstream (`libp2p`) and an `iceConnectionState` failure occurred but had no hint to the origin of the failure.

Thanks 😸 