### PR TITLE
Fixed incorrect getStats usage with wrtc

### DIFF
--- a/index.js
+++ b/index.js
@@ -438,6 +438,16 @@ Peer.prototype.getStats = function (cb) {
       cb(items)
     }, function (err) { self._onError(err) })
 
+  // Node.js with wrtc (callback version)
+  } else if (self._isWrtc) {
+    self._pc.getStats(function (res) {
+      var items = []
+      res.result().forEach(function (item) {
+        items.push(item)
+      })
+      cb(items)
+    }, function (err) { self._onError(err) })
+
   // Fallback (standards-compliant, callback version, deprecated)
   } else {
     self._pc.getStats(null, function (res) {


### PR DESCRIPTION
The wrtc getStats signature does not conform to the expected fallback. See https://github.com/js-platform/node-webrtc/blob/develop/lib/peerconnection.js.

Added another option to find whether we are using wrtc and use the wrtc conventions in that case.