### PR TITLE
remove debugging console.log leftovers

### DIFF
--- a/index.js
+++ b/index.js
@@ -545,10 +545,6 @@ Peer.prototype._maybeReady = function () {
       )
     }
 
-    console.log(items)
-    console.log(remoteCandidates)
-    console.log(localCandidates)
-
     if (self._chunk) {
       try {
         self.send(self._chunk)


### PR DESCRIPTION
@feross, tried the latest version and works like a charm, thank you :) 

I found that there were 3 console.logs left, probably leftovers from testing