### PR TITLE
Transform constraints objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -694,7 +694,7 @@ Peer.prototype._transformConstraints = function (constraints) {
     return constraints
   }
 
-  if ((constraints.mandatory || constraints.optional) && self.isChromium) {
+  if ((constraints.mandatory || constraints.optional) && self._isChromium) {
     // convert to new format
 
     // Merge mandatory and optional objects, prioritizing mandatory
@@ -712,7 +712,7 @@ Peer.prototype._transformConstraints = function (constraints) {
     }
 
     return newConstraints
-  } else if (!constraints.mandatory && !constraints.optional && self.isChromium) {
+  } else if (!constraints.mandatory && !constraints.optional && self._isChromium) {
     // convert to old format
 
     // fix casing

--- a/test/basic.js
+++ b/test/basic.js
@@ -121,3 +121,53 @@ test('sdpTransform function is called', function (t) {
     peer1.signal(data)
   })
 })
+
+test('old constraint formats are used', function (t) {
+  t.plan(1)
+
+  var constraints = {
+    mandatory: {
+      OfferToReceiveAudio: true,
+      OfferToReceiveVideo: true
+    }
+  }
+
+  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc, constraints: constraints })
+  var peer2 = new Peer({ config: config, wrtc: common.wrtc, constraints: constraints })
+
+  peer1.on('signal', function (data) {
+    peer2.signal(data)
+  })
+
+  peer2.on('signal', function (data) {
+    peer1.signal(data)
+  })
+
+  peer1.on('connect', function () {
+    t.pass('peers connected')
+  })
+})
+
+test('new constraint formats are used', function (t) {
+  t.plan(1)
+
+  var constraints = {
+    offerToReceiveAudio: true,
+    offerToReceiveVideo: true
+  }
+
+  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc, constraints: constraints })
+  var peer2 = new Peer({ config: config, wrtc: common.wrtc, constraints: constraints })
+
+  peer1.on('signal', function (data) {
+    peer2.signal(data)
+  })
+
+  peer2.on('signal', function (data) {
+    peer1.signal(data)
+  })
+
+  peer1.on('connect', function () {
+    t.pass('peers connected')
+  })
+})


### PR DESCRIPTION
Implements #145 

Added a function that transforms constraint objects into either the old or new formats.

Unfortunately browser detection is the only way I can think of to do this... currently detects Chromium (the only browser that needs the old format) via `window.chrome`. Any objections?