### PR TITLE
Listen to 'negotiationneeded' before calling pc.addStream()

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,22 @@ function Peer (opts) {
     self._onIceCandidate(event)
   }
 
+  if (self.initiator) {
+    var createdOffer = false
+    self._pc.onnegotiationneeded = function () {
+      if (!createdOffer) self._createOffer()
+      createdOffer = true
+    }
+
+    self._setupData({
+      channel: self._pc.createDataChannel(self.channelName, self.channelConfig)
+    })
+  } else {
+    self._pc.ondatachannel = function (event) {
+      self._setupData(event)
+    }
+  }
+
   if (self.stream) self._pc.addStream(self.stream)
 
   if ('ontrack' in self._pc) {
@@ -107,23 +123,9 @@ function Peer (opts) {
   }
 
   if (self.initiator) {
-    var createdOffer = false
-    self._pc.onnegotiationneeded = function () {
-      if (!createdOffer) self._createOffer()
-      createdOffer = true
-    }
-
-    self._setupData({
-      channel: self._pc.createDataChannel(self.channelName, self.channelConfig)
-    })
-
     // HACK: wrtc doesn't fire the 'negotionneeded' event
     if (self._isWrtc) {
       self._pc.onnegotiationneeded()
-    }
-  } else {
-    self._pc.ondatachannel = function (event) {
-      self._setupData(event)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -123,11 +123,9 @@ function Peer (opts) {
     }
   }
 
-  if (self.initiator) {
-    // HACK: wrtc doesn't fire the 'negotionneeded' event
-    if (self._isWrtc) {
-      self._pc.onnegotiationneeded()
-    }
+  // HACK: wrtc doesn't fire the 'negotionneeded' event
+  if (self.initiator && self._isWrtc) {
+    self._pc.onnegotiationneeded()
   }
 
   self._onFinishBound = function () {


### PR DESCRIPTION
Fixes https://github.com/feross/simple-peer/issues/143

We used to manually `call self._pc.onnegotiationneeded()` for Firefox, but I discovered it wasn't needed anymore since Firefox has finally implemented the event. So I removed that call for Firefox, leaving it only for `wrtc`. The mistake I made is that we're calling `addStream()` before we attach the 'negotiationneeded' handler, so it's firing before we're listening for it.