### PR TITLE
Use addTrack() instead of addStream() in supported browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,15 +111,19 @@ function Peer (opts) {
     }
   }
 
-  if (self.stream) self._pc.addStream(self.stream)
-
   if ('ontrack' in self._pc) {
     // WebRTC Spec, Firefox
+    if (self.stream) {
+      self.stream.getTracks().forEach(function (track) {
+        self._pc.addTrack(track, self.stream)
+      })
+    }
     self._pc.ontrack = function (event) {
       self._onTrack(event)
     }
   } else {
     // Chrome, etc. This can be removed once all browsers support `ontrack`
+    if (self.stream) self._pc.addStream(self.stream)
     self._pc.onaddstream = function (event) {
       self._onAddStream(event)
     }


### PR DESCRIPTION
`addStream()` is deprecated, so let's use `addTrack()` if the browser
supports it.

Docs that show the deprecation: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream