### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,8 @@ the other peer.** This usually entails using a websocket signaling server. This 
 `Object`, so  remember to call `JSON.stringify(data)` to serialize it first. Then, simply
 call `peer.signal(data)` on the remote peer.
 
+**To avoid losing the signaling answer, you need to listen for this event before calling `peer.signal(data)` with the offer.**
+
 ### `peer.on('connect', function () {})`
 
 Fired when the peer connection and data channel are ready to use.

--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ the other peer.** This usually entails using a websocket signaling server. This 
 `Object`, so  remember to call `JSON.stringify(data)` to serialize it first. Then, simply
 call `peer.signal(data)` on the remote peer.
 
-**To avoid losing the signaling answer, you need to listen for this event before calling `peer.signal(data)` with the offer.**
+(Be sure to listen to this event immediately to avoid missing it. For `initiator: true`
+peers, it fires right away. For `initatior: false` peers, it fires when the remote
+offer is received.)
 
 ### `peer.on('connect', function () {})`
 


### PR DESCRIPTION
I spent a day debugging because I had assumed the signal answers were queued if no event listener had been registered yet. They are actually silently dropped. I added a note to the README (quick fix).

Maybe a code fix would prevent the issue.