### PR TITLE
Fix channelName assign bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function Peer (opts) {
 
   stream.Duplex.call(self, opts)
 
-  opts.channelName ? self.channelName = opts.channelName : randombytes(20).toString('hex')
+  opts.channelName ? self.channelName = opts.channelName : self.channelName = randombytes(20).toString('hex')
 
   // Needed by _transformConstraints, so set this early
   self._isChromium = typeof window !== 'undefined' && !!window.webkitRTCPeerConnection

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function Peer (opts) {
   stream.Duplex.call(self, opts)
 
   self.channelName = opts.channelName || randombytes(20).toString('hex')
-  
+
   // Needed by _transformConstraints, so set this early
   self._isChromium = typeof window !== 'undefined' && !!window.webkitRTCPeerConnection
 

--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ function Peer (opts) {
 
   stream.Duplex.call(self, opts)
 
-  opts.channelName ? self.channelName = opts.channelName : self.channelName = randombytes(20).toString('hex')
-
+  self.channelName = opts.channelName || randombytes(20).toString('hex')
+  
   // Needed by _transformConstraints, so set this early
   self._isChromium = typeof window !== 'undefined' && !!window.webkitRTCPeerConnection
 

--- a/index.js
+++ b/index.js
@@ -28,9 +28,7 @@ function Peer (opts) {
 
   stream.Duplex.call(self, opts)
 
-  self.channelName = opts.initiator
-    ? opts.channelName || randombytes(20).toString('hex')
-    : null
+  opts.channelName ? self.channelName = opts.channelName : randombytes(20).toString('hex')
 
   // Needed by _transformConstraints, so set this early
   self._isChromium = typeof window !== 'undefined' && !!window.webkitRTCPeerConnection


### PR DESCRIPTION
An incorrect name was assigned if the instance was not an initiator.