### PR TITLE
Fix ice candidates being added before valid remoteDescription is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ Peer.prototype.signal = function (data) {
   self._debug('signal()')
 
   if (data.candidate) {
-    if (self._pc.remoteDescription) self._addIceCandidate(data.candidate)
+    if (self._pc.remoteDescription && self._pc.remoteDescription.type) self._addIceCandidate(data.candidate)
     else self._pendingCandidates.push(data.candidate)
   }
   if (data.sdp) {


### PR DESCRIPTION
Refactor of #185.

When the remoteDescription is set, it can sometimes still have an empty type field, making the check a little more complex. My guess is incorrect SDP information, but I think this is preferable to munging the SDP lines.

Incorrect Ice Candidate errors (which I've only noticed with coturn servers) vanish when this fix is applied.

Thanks to @cdvv7788 for the initial PR.