### PR TITLE
changing tracks, multistreaming and renegotiation

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -1,4 +1,5 @@
 sauce_connect: true
+loopback: airtap.local
 browsers:
   - name: firefox
     version: latest

--- a/.airtap.yml
+++ b/.airtap.yml
@@ -1,5 +1,4 @@
 sauce_connect: true
-loopback: airtap.local
 browsers:
   - name: firefox
     version: latest

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ If `opts` is specified, then the default options (shown below) will be overridde
   reconnectTimer: false,
   sdpTransform: function (sdp) { return sdp },
   stream: false,
+  streams: [],
+  tracks: [],
   trickle: true,
   wrtc: {}, // RTCPeerConnection/RTCSessionDescription/RTCIceCandidate
   objectMode: false
@@ -236,6 +238,8 @@ The options do the following:
 - `reconnectTimer` - wait __ milliseconds after ICE 'disconnect' for reconnect attempt before emitting 'close'
 - `sdpTransform` - function to transform the generated SDP signaling data (for advanced users)
 - `stream` - if video/voice is desired, pass stream returned from `getUserMedia`
+- `streams` - an array of MediaStreams returned from `getUserMedia`
+- `tracks` - an array of MediaStreamTracks
 - `trickle` - set to `false` to disable [trickle ICE](http://webrtchacks.com/trickle-ice/) and get a single 'signal' event (slower)
 - `wrtc` - custom webrtc implementation, mainly useful in node to specify in the [wrtc](https://npmjs.com/package/wrtc) package
 - `objectMode` - set to `true` to create the stream in [Object Mode](https://nodejs.org/api/stream.html#stream_object_mode). In this mode, incoming string data is not automatically converted to `Buffer` objects.
@@ -258,6 +262,18 @@ etc.), `ArrayBuffer`, or `Blob` (in browsers that support it).
 
 Note: If this method is called before the `peer.on('connect')` event has fired, then data
 will be buffered.
+
+### `peer.addStream(stream)`
+
+Add a MediaStream to the connection. Will not take effect until `peer.renegotiate()` is called.
+
+### `peer.addTrack(track)`
+
+Add a MediaStreamTrack to the connection. Will not take effect until `peer.renegotiate()` is called.
+
+### `peer.renegotiate()`
+
+Renegotiate the connection. Calls to `addStream` and `addTrack` will not take effect until this is called.
 
 ### `peer.destroy([err])`
 
@@ -334,6 +350,10 @@ peer.on('stream', function (stream) {
   video.play()
 })
 ```
+
+### `peer.on('track', function (track) {})`
+
+Received a remote video track. Streams contain multiple tracks.
 
 ### `peer.on('close', function () {})`
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Remove the track associated with a `RTCRtpSender`. Will not take effect until `p
 
 ### `peer.renegotiate()`
 
-Renegotiate the connection. Changes to streams or tracks will not take effect until this is called. You do not need to call this if your streams were added in the `Peer` constructor.
+Renegotiate the connection. Changes to streams or tracks will not take effect until this is called. You do not need to call this if your streams were added through the `Peer` constructor.
 
 ### `peer.destroy([err])`
 

--- a/README.md
+++ b/README.md
@@ -263,27 +263,19 @@ will be buffered.
 
 ### `peer.addStream(stream)`
 
-Add a `MediaStream` to the connection. Will not take effect until `peer.renegotiate()` is called.
+Add a `MediaStream` to the connection.
 
-Returns a `RTCRtpSender` array that you can pass into `peer.removeStream()`.
+### `peer.removeStream(stream)`
 
-### `peer.removeStream(senders)`
-
-Remove all tracks associated with a `RTCRtpSender` array. Will not take effect until `peer.renegotiate()` is called.
+Remove a `MediaStream` from the connection.
 
 ### `peer.addTrack(track, stream)`
 
-Add a `MediaStreamTrack` to the connection. Must also pass the `MediaStream` you want to attatch it to. Will not take effect until `peer.renegotiate()` is called.
+Add a `MediaStreamTrack` to the connection. Must also pass the `MediaStream` you want to attach it to.
 
-Returns a `RTCRtpSender` that you can pass into `peer.removeTrack()`.
+### `peer.removeTrack(track)`
 
-### `peer.removeTrack(sender)`
-
-Remove the track associated with a `RTCRtpSender`. Will not take effect until `peer.renegotiate()` is called.
-
-### `peer.renegotiate()`
-
-Renegotiate the connection. Changes to streams or tracks will not take effect until this is called. You do not need to call this if your streams were added through the `Peer` constructor.
+Remove a `MediaStreamTrack` from the connection.
 
 ### `peer.destroy([err])`
 
@@ -372,10 +364,6 @@ Received a remote audio/video track. Streams may contain multiple tracks.
 ### `peer.on('removetrack', function (track) {})`
 
 Fired when the remote peer removes a audio/video track from the connection.
-
-### `peer.on('negotiate', function () {})`
-
-Fired when a round of session negotiation is completed. More negotiation may still be required.
 
 ### `peer.on('close', function () {})`
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,6 @@ If `opts` is specified, then the default options (shown below) will be overridde
   sdpTransform: function (sdp) { return sdp },
   stream: false,
   streams: [],
-  tracks: [],
   trickle: true,
   wrtc: {}, // RTCPeerConnection/RTCSessionDescription/RTCIceCandidate
   objectMode: false
@@ -239,7 +238,6 @@ The options do the following:
 - `sdpTransform` - function to transform the generated SDP signaling data (for advanced users)
 - `stream` - if video/voice is desired, pass stream returned from `getUserMedia`
 - `streams` - an array of MediaStreams returned from `getUserMedia`
-- `tracks` - an array of MediaStreamTracks
 - `trickle` - set to `false` to disable [trickle ICE](http://webrtchacks.com/trickle-ice/) and get a single 'signal' event (slower)
 - `wrtc` - custom webrtc implementation, mainly useful in node to specify in the [wrtc](https://npmjs.com/package/wrtc) package
 - `objectMode` - set to `true` to create the stream in [Object Mode](https://nodejs.org/api/stream.html#stream_object_mode). In this mode, incoming string data is not automatically converted to `Buffer` objects.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Remove the track associated with a `RTCRtpSender`. Will not take effect until `p
 
 ### `peer.renegotiate()`
 
-Renegotiate the connection. Calls to `addStream` and `addTrack` will not take effect until this is called.
+Renegotiate the connection. Changes to streams or tracks will not take effect until this is called. You do not need to call this if your streams were added in the `Peer` constructor.
 
 ### `peer.destroy([err])`
 

--- a/README.md
+++ b/README.md
@@ -265,11 +265,23 @@ will be buffered.
 
 ### `peer.addStream(stream)`
 
-Add a MediaStream to the connection. Will not take effect until `peer.renegotiate()` is called.
+Add a `MediaStream` to the connection. Will not take effect until `peer.renegotiate()` is called.
+
+Returns a `RTCRtpSender` array that you can pass into `peer.removeStream()`.
+
+### `peer.removeStream(senders)`
+
+Remove all tracks associated with a `RTCRtpSender` array. Will not take effect until `peer.renegotiate()` is called.
 
 ### `peer.addTrack(track, stream)`
 
-Add a MediaStreamTrack to the connection. Must also pass the MediaStream you want to attatch it to. Will not take effect until `peer.renegotiate()` is called.
+Add a `MediaStreamTrack` to the connection. Must also pass the MediaStream you want to attatch it to. Will not take effect until `peer.renegotiate()` is called.
+
+Returns a `RTCRtpSender` that you can pass into `peer.removeTrack()`.
+
+### `peer.removeTrack(sender)`
+
+Remove the track associated with a `RTCRtpSender`. Will not take effect until `peer.renegotiate()` is called.
 
 ### `peer.renegotiate()`
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Remove all tracks associated with a `RTCRtpSender` array. Will not take effect u
 
 ### `peer.addTrack(track, stream)`
 
-Add a `MediaStreamTrack` to the connection. Must also pass the MediaStream you want to attatch it to. Will not take effect until `peer.renegotiate()` is called.
+Add a `MediaStreamTrack` to the connection. Must also pass the `MediaStream` you want to attatch it to. Will not take effect until `peer.renegotiate()` is called.
 
 Returns a `RTCRtpSender` that you can pass into `peer.removeTrack()`.
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ peer.on('stream', function (stream) {
 })
 ```
 
-### `peer.on('track', function (track) {})`
+### `peer.on('track', function (track, stream) {})`
 
 Received a remote audio/video track. Streams may contain multiple tracks.
 
@@ -361,7 +361,7 @@ Received a remote audio/video track. Streams may contain multiple tracks.
 
 Fired when the remote peer removes all of a video stream's tracks from the connection.
 
-### `peer.on('removetrack', function (track) {})`
+### `peer.on('removetrack', function (track, stream) {})`
 
 Fired when the remote peer removes a audio/video track from the connection.
 

--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ will be buffered.
 
 Add a MediaStream to the connection. Will not take effect until `peer.renegotiate()` is called.
 
-### `peer.addTrack(track)`
+### `peer.addTrack(track, stream)`
 
-Add a MediaStreamTrack to the connection. Will not take effect until `peer.renegotiate()` is called.
+Add a MediaStreamTrack to the connection. Must also pass the MediaStream you want to attatch it to. Will not take effect until `peer.renegotiate()` is called.
 
 ### `peer.renegotiate()`
 
@@ -351,9 +351,21 @@ peer.on('stream', function (stream) {
 })
 ```
 
+### `peer.on('removestream', function (stream) {})`
+
+Fired when the remote peer removes all of a video stream's tracks from the connection.
+
 ### `peer.on('track', function (track) {})`
 
-Received a remote video track. Streams contain multiple tracks.
+Received a remote audio/video track. Streams may contain multiple tracks.
+
+### `peer.on('removetrack', function (track) {})`
+
+Fired when the remote peer removes a audio/video track from the connection.
+
+### `peer.on('negotiate', function () {})`
+
+Fired when a round of session negotiation is completed. More negotiation may still be required.
 
 ### `peer.on('close', function () {})`
 

--- a/README.md
+++ b/README.md
@@ -273,9 +273,9 @@ Remove a `MediaStream` from the connection.
 
 Add a `MediaStreamTrack` to the connection. Must also pass the `MediaStream` you want to attach it to.
 
-### `peer.removeTrack(track)`
+### `peer.removeTrack(track, stream)`
 
-Remove a `MediaStreamTrack` from the connection.
+Remove a `MediaStreamTrack` from the connection. Must also pass the `MediaStream` that it was attached to.
 
 ### `peer.destroy([err])`
 
@@ -353,13 +353,13 @@ peer.on('stream', function (stream) {
 })
 ```
 
-### `peer.on('removestream', function (stream) {})`
-
-Fired when the remote peer removes all of a video stream's tracks from the connection.
-
 ### `peer.on('track', function (track) {})`
 
 Received a remote audio/video track. Streams may contain multiple tracks.
+
+### `peer.on('removestream', function (stream) {})`
+
+Fired when the remote peer removes all of a video stream's tracks from the connection.
 
 ### `peer.on('removetrack', function (track) {})`
 

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function Peer (opts) {
   self._channel = null
   self._pendingCandidates = []
 
-  self._initialNegotiation = true 
+  self._initialNegotiation = true
   self._isNegotiating = false
   self._queuedNegotiation = false // is there a queued negotiation request?
   self._sendersAwaitingStable = []
@@ -126,7 +126,7 @@ function Peer (opts) {
   if ('addTrack' in self._pc) {
     if (self.streams) {
       self.streams.forEach(function (stream) {
-        self._negotationsToIgnore+=stream.getTracks().length
+        self._negotationsToIgnore += stream.getTracks().length
         self.addStream(stream)
       })
     }
@@ -255,7 +255,7 @@ Peer.prototype.addStream = function (stream) {
   self._debug('addStream()')
 
   var senders = []
-  stream.getTracks().forEach(function(track) {
+  stream.getTracks().forEach(function (track) {
     senders.push(self.addTrack(track, stream))
   })
   return senders
@@ -285,7 +285,7 @@ Peer.prototype.addStream = function (stream) {
   self._debug('addStream()')
 
   var senders = []
-  stream.getTracks().forEach(function(track) {
+  stream.getTracks().forEach(function (track) {
     senders.push(self.addTrack(track, stream))
   })
   return senders
@@ -305,7 +305,7 @@ Peer.prototype.removeSender = function (sender) {
     self._pc.removeTrack(sender)
   } catch (err) {
     if (err.name === 'NS_ERROR_UNEXPECTED') {
-      self._sendersAwaitingStable.push(send) // HACK: Firefox must wait until (signalingState === stable) https://bugzilla.mozilla.org/show_bug.cgi?id=1133874
+      self._sendersAwaitingStable.push(sender) // HACK: Firefox must wait until (signalingState === stable) https://bugzilla.mozilla.org/show_bug.cgi?id=1133874
     } else {
       self.destroy(err)
     }
@@ -877,10 +877,9 @@ Peer.prototype._onTrack = function (event) {
   self._debug('on track')
   self.emit('track', event.track)
 
-  var id = event.streams[0].id
   if (self._remoteStreams.some(function (stream) {
     return stream.id === event.streams[0].id // Only fire one 'stream' event, even though there may be multiple tracks per stream
-  })) return 
+  })) return
   self._remoteStreams.push(event.streams[0])
   setTimeout(function () {
     self.emit('stream', event.streams[0]) // ensure all tracks have been added
@@ -931,8 +930,7 @@ Peer.prototype._checkForRemovals = function (sdp) {
 
 // parse ssrc msids out of an SDP remote description
 Peer.prototype._parseMsids = function (sdp) {
-
-  // Chromium's format
+  // Chromium's a=ssrc format
   var chromium = sdp.split('\n').filter(function (line) {
     return (line.indexOf('a=ssrc:') === 0) && (line.indexOf(' msid:') !== -1)
   }).map(function (line) {
@@ -943,7 +941,7 @@ Peer.prototype._parseMsids = function (sdp) {
     }
   })
 
-  // Firefox/Safari's format
+  // Firefox/Safari's a=msid format
   var firefox = sdp.split('\n').filter(function (line) {
     return (line.indexOf('a=msid:{') === 0)
   }).map(function (line) {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ function Peer (opts) {
   self.reconnectTimer = opts.reconnectTimer || false
   self.sdpTransform = opts.sdpTransform || function (sdp) { return sdp }
   self.streams = opts.streams || (opts.stream ? [opts.stream] : []) // support old "stream" option
-  self.tracks = opts.tracks || []
   self.trickle = opts.trickle !== undefined ? opts.trickle : true
 
   self.destroyed = false
@@ -128,12 +127,6 @@ function Peer (opts) {
       self.streams.forEach(function (stream) {
         self._negotationsToIgnore += stream.getTracks().length
         self.addStream(stream)
-      })
-    }
-    if (self.tracks) {
-      self.tracks.forEach(function (track) {
-        self._negotationsToIgnore++
-        self.addTrack(track, null)
       })
     }
     self._pc.ontrack = function (event) {

--- a/index.js
+++ b/index.js
@@ -73,9 +73,9 @@ function Peer (opts) {
   self._channel = null
   self._pendingCandidates = []
 
-  self._isNegotiating = false       // is this peer waiting for negotiation to complete?
-  self._batchedNegotiation = false  // batch synchronous negotiations
-  self._queuedNegotiation = false   // is there a queued negotiation request?
+  self._isNegotiating = false // is this peer waiting for negotiation to complete?
+  self._batchedNegotiation = false // batch synchronous negotiations
+  self._queuedNegotiation = false // is there a queued negotiation request?
   self._sendersAwaitingStable = []
   self._senderMap = new WeakMap()
 

--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ Peer.prototype.addStream = function (stream) {
 }
 
 /**
- * Add a MediaStreamTrack to the connection. 
+ * Add a MediaStreamTrack to the connection.
  * @param {MediaStreamTrack} track
  */
 Peer.prototype.addTrack = function (track, stream) {
@@ -850,7 +850,7 @@ Peer.prototype._onTrack = function (event) {
 
   event.streams.forEach(function (eventStream) {
     if (self._remoteStreams.some(function (remoteStream) {
-      return remoteStream.id === eventStream.id 
+      return remoteStream.id === eventStream.id
     })) return // Only fire one 'stream' event, even though there may be multiple tracks per stream
 
     self._remoteStreams.push(eventStream)

--- a/test/common.js
+++ b/test/common.js
@@ -29,3 +29,22 @@ if (process.env.WRTC === 'wrtc') {
     }
   })
 }
+
+// create a test MediaStream with two tracks
+var audioContext
+exports.getMediaStream = function () {
+  if (!audioContext) audioContext = new (window.AudioContext || window.webkitAudioContext)()
+  var oscillator = audioContext.createOscillator()
+  var dst = audioContext.createMediaStreamDestination()
+  oscillator.connect(dst)
+  oscillator.start()
+
+  var oscillator2 = audioContext.createOscillator()
+  var dst2 = audioContext.createMediaStreamDestination()
+  oscillator2.connect(dst2)
+  oscillator2.start()
+
+  var track = dst2.stream.getTracks()[0]
+  dst.stream.addTrack(track)
+  return dst.stream
+}

--- a/test/multistream.js
+++ b/test/multistream.js
@@ -1,0 +1,99 @@
+var common = require('./common')
+var Peer = require('../')
+var test = require('tape')
+
+var config
+test('get config', function (t) {
+  common.getConfig(function (err, _config) {
+    if (err) return t.fail(err)
+    config = _config
+    t.end()
+  })
+})
+
+test('multistream', function (t) {
+  if (common.wrtc) {
+    t.pass('Skipping test, no MediaStream support on wrtc')
+    t.end()
+    return
+  }
+  t.plan(20)
+
+  var peer1 = new Peer({
+    config: config,
+    initiator: true,
+    wrtc: common.wrtc,
+    streams: (new Array(10)).fill(null).map(function () { return common.getMediaStream() })
+  })
+  var peer2 = new Peer({
+    config: config,
+    renegotiation: true,
+    wrtc: common.wrtc,
+    streams: (new Array(10)).fill(null).map(function () { return common.getMediaStream() })
+  })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  peer1.on('stream', function () {
+    t.pass('peer1 got stream')
+  })
+  peer2.on('stream', function () {
+    t.pass('peer2 got stream')
+  })
+})
+
+test('incremental multistream', function (t) {
+  if (common.wrtc) {
+    t.pass('Skipping test, no MediaStream support on wrtc')
+    t.end()
+    return
+  }
+  t.plan(12)
+
+  var peer1 = new Peer({
+    config: config,
+    initiator: true,
+    wrtc: common.wrtc,
+    streams: []
+  })
+  var peer2 = new Peer({
+    config: config,
+    wrtc: common.wrtc,
+    streams: []
+  })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  peer1.on('connect', function () {
+    t.pass('peer1 connected')
+    peer1.addStream(common.getMediaStream())
+    peer1.renegotiate()
+  })
+  peer2.on('connect', function () {
+    t.pass('peer2 connected')
+    peer2.addStream(common.getMediaStream())
+    peer2.renegotiate()
+  })
+
+  var count1 = 0
+  peer1.on('stream', function () {
+    t.pass('peer1 got stream')
+    count1++
+    if (count1 < 5) {
+      peer1.addStream(common.getMediaStream())
+      peer1.renegotiate()
+    }
+  })
+
+  var count2 = 0
+  peer2.on('stream', function () {
+    t.pass('peer2 got stream')
+    count2++
+    if (count2 < 5) {
+      peer2.addStream(common.getMediaStream())
+      peer2.renegotiate()
+    }
+  })
+})

--- a/test/multistream.js
+++ b/test/multistream.js
@@ -152,7 +152,7 @@ test('removeTrack immediately', function (t) {
   peer1.on('removetrack', function (track) {
     t.fail('remote removetrack not received')
   })
-  
+
   peer2.on('track', function (track) {
     t.fail('peer2 did not get track event')
   })

--- a/test/multistream.js
+++ b/test/multistream.js
@@ -137,8 +137,8 @@ test('removeTrack immediately', function (t) {
   peer1.addTrack(stream1.getTracks()[0], stream1)
   peer2.addTrack(stream2.getTracks()[0], stream2)
 
-  peer1.removeTrack(stream1.getTracks()[0])
-  peer2.removeTrack(stream2.getTracks()[0])
+  peer1.removeTrack(stream1.getTracks()[0], stream1)
+  peer2.removeTrack(stream2.getTracks()[0], stream2)
 
   peer1.on('track', function (track) {
     t.fail('peer1 did not get track event')

--- a/test/multistream.js
+++ b/test/multistream.js
@@ -27,7 +27,6 @@ test('multistream', function (t) {
   })
   var peer2 = new Peer({
     config: config,
-    renegotiation: true,
     wrtc: common.wrtc,
     streams: (new Array(10)).fill(null).map(function () { return common.getMediaStream() })
   })
@@ -81,12 +80,10 @@ test('incremental multistream', function (t) {
   peer1.on('connect', function () {
     t.pass('peer1 connected')
     peer1.addStream(common.getMediaStream())
-    peer1.renegotiate()
   })
   peer2.on('connect', function () {
     t.pass('peer2 connected')
     peer2.addStream(common.getMediaStream())
-    peer2.renegotiate()
   })
 
   var receivedIds = {}
@@ -102,7 +99,6 @@ test('incremental multistream', function (t) {
     count1++
     if (count1 < 5) {
       peer1.addStream(common.getMediaStream())
-      peer1.renegotiate()
     }
   })
 
@@ -117,7 +113,6 @@ test('incremental multistream', function (t) {
     count2++
     if (count2 < 5) {
       peer2.addStream(common.getMediaStream())
-      peer2.renegotiate()
     }
   })
 })
@@ -139,12 +134,11 @@ test('removeTrack immediately', function (t) {
   var stream1 = common.getMediaStream()
   var stream2 = common.getMediaStream()
 
-  var sender1 = peer1.addTrack(stream1.getTracks()[0], stream1)
-  var sender2 = peer2.addTrack(stream2.getTracks()[0], stream2)
+  peer1.addTrack(stream1.getTracks()[0], stream1)
+  peer2.addTrack(stream2.getTracks()[0], stream2)
 
-  peer1.removeTrack(sender1)
-  peer2.removeTrack(sender2)
-  peer1.renegotiate()
+  peer1.removeTrack(stream1.getTracks()[0])
+  peer2.removeTrack(stream2.getTracks()[0])
 
   peer1.on('track', function (track) {
     t.fail('peer1 did not get track event')

--- a/test/negotiation.js
+++ b/test/negotiation.js
@@ -220,7 +220,7 @@ test('renegotiation after removeTrack', function (t) {
   peer1.on('removetrack', function (track) {
     t.pass('remote removetrack received')
   })
-  
+
   peer2.on('stream', function (stream) {
     t.equals(stream.getTracks().length, 1, 'peer2 got stream with right tracks')
     peer1.removeTrack(sender1)

--- a/test/negotiation.js
+++ b/test/negotiation.js
@@ -209,7 +209,7 @@ test('renegotiation after removeTrack', function (t) {
 
   peer1.on('stream', function (stream) {
     t.equals(stream.getTracks().length, 1, 'peer1 got stream with right tracks')
-    peer2.removeTrack(stream2.getTracks()[0])
+    peer2.removeTrack(stream2.getTracks()[0], stream2)
   })
   peer1.on('track', function (track) {
     t.pass('peer1 got track event')
@@ -220,7 +220,7 @@ test('renegotiation after removeTrack', function (t) {
 
   peer2.on('stream', function (stream) {
     t.equals(stream.getTracks().length, 1, 'peer2 got stream with right tracks')
-    peer1.removeTrack(stream1.getTracks()[0])
+    peer1.removeTrack(stream1.getTracks()[0], stream1)
   })
   peer2.on('track', function (track) {
     t.pass('peer2 got track event')

--- a/test/negotiation.js
+++ b/test/negotiation.js
@@ -1,0 +1,176 @@
+var common = require('./common')
+var Peer = require('../')
+var test = require('tape')
+
+var config
+test('get config', function (t) {
+  common.getConfig(function (err, _config) {
+    if (err) return t.fail(err)
+    config = _config
+    t.end()
+  })
+})
+
+test('single negotiation {renegotiation: false}', function (t) {
+  if (common.wrtc) {
+    t.pass('Skipping test, no MediaStream support on wrtc')
+    t.end()
+    return
+  }
+  t.plan(4)
+
+  var peer1 = new Peer({ config: config, initiator: true, renegotiation: false, stream: common.getMediaStream(), wrtc: common.wrtc })
+  var peer2 = new Peer({ config: config, renegotiation: false, stream: common.getMediaStream(), wrtc: common.wrtc })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  peer1.on('connect', function () {
+    t.pass('peer1 connected')
+  })
+  peer2.on('connect', function () {
+    t.pass('peer2 connected')
+  })
+
+  peer1.on('stream', function (stream) {
+    t.equal(stream.getTracks().length, 2, 'peer1 got stream with right tracks')
+  })
+  peer2.on('stream', function (stream) {
+    t.equal(stream.getTracks().length, 2, 'peer2 got stream with right tracks')
+  })
+})
+
+test('single negotiation {renegotiation: true}', function (t) {
+  if (common.wrtc) {
+    t.pass('Skipping test, no MediaStream support on wrtc')
+    t.end()
+    return
+  }
+  t.plan(10)
+
+  var peer1 = new Peer({ config: config, initiator: true, renegotiation: true, stream: common.getMediaStream(), wrtc: common.wrtc })
+  var peer2 = new Peer({ config: config, renegotiation: true, stream: common.getMediaStream(), wrtc: common.wrtc })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  peer1.on('connect', function () {
+    t.pass('peer1 connected')
+  })
+  peer2.on('connect', function () {
+    t.pass('peer2 connected')
+  })
+
+  peer1.on('stream', function (stream) {
+    t.pass('peer1 got stream')
+  })
+  peer2.on('stream', function (stream) {
+    t.pass('peer2 got stream')
+  })
+
+  var trackCount1 = 0
+  peer1.on('track', function (track) {
+    t.pass('peer1 got track')
+    trackCount1++
+    if (trackCount1 >= 2) {
+      t.pass('got correct number of tracks')
+    }
+  })
+  var trackCount2 = 0
+  peer2.on('track', function (track) {
+    t.pass('peer2 got track')
+    trackCount2++
+    if (trackCount2 >= 2) {
+      t.pass('got correct number of tracks')
+    }
+  })
+})
+
+test('forced renegotiation', function (t) {
+  // wrtc should be able to run this test
+  t.plan(2)
+
+  var peer1 = new Peer({ config: config, initiator: true, renegotiation: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config: config, renegotiation: true, wrtc: common.wrtc })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  peer1.on('connect', function () {
+    peer1.renegotiate()
+    peer1.on('negotiate', function () {
+      t.pass('peer1 negotiated')
+    })
+    peer2.on('negotiate', function () {
+      t.pass('peer2 negotiated')
+    })
+  })
+})
+
+test('repeated forced renegotiation', function (t) {
+  t.plan(6)
+
+  var peer1 = new Peer({ config: config, initiator: true, renegotiation: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config: config, renegotiation: true, wrtc: common.wrtc })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  peer1.once('connect', function () {
+    peer1.renegotiate()
+  })
+  peer1.once('negotiate', function () {
+    t.pass('peer1 negotiated')
+    peer1.renegotiate()
+    peer1.once('negotiate', function () {
+      t.pass('peer1 negotiated again')
+      peer1.renegotiate()
+      peer1.once('negotiate', function () {
+        t.pass('peer1 negotiated again')
+      })
+    })
+  })
+  peer2.once('negotiate', function () {
+    t.pass('peer2 negotiated')
+    peer2.renegotiate()
+    peer2.once('negotiate', function () {
+      t.pass('peer2 negotiated again')
+      peer1.renegotiate()
+      peer1.once('negotiate', function () {
+        t.pass('peer1 negotiated again')
+      })
+    })
+  })
+})
+
+test('renegotiation after addStream', function (t) {
+  if (common.wrtc) {
+    t.pass('Skipping test, no MediaStream support on wrtc')
+    t.end()
+    return
+  }
+  t.plan(4)
+
+  var peer1 = new Peer({ config: config, initiator: true, renegotiation: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config: config, renegotiation: true, wrtc: common.wrtc })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  peer1.on('connect', function () {
+    t.pass('peer1 connect')
+    peer1.addStream(common.getMediaStream())
+    peer1.renegotiate()
+  })
+  peer2.on('connect', function () {
+    t.pass('peer2 connect')
+    peer2.addStream(common.getMediaStream())
+    peer2.renegotiate()
+  })
+  peer1.on('stream', function () {
+    t.pass('peer1 got stream')
+  })
+  peer2.on('stream', function () {
+    t.pass('peer2 got stream')
+  })
+})


### PR DESCRIPTION
The WebRTC API around tracks and multistreaming is finally stable enough to implement this.

Stream methods are convenience wrappers for the track methods. Native addStream, onAddStream usage has been removed since all major browsers support tracks now.

Exposed API:
- `addStream(MediaStream)`
- `addTrack(MediaStreamTrack)`
- `removeStream(RTCRtpSender[])`
- `removeTrack(RTCRtpSender)`
- `peer.on('stream')`
- `peer.on('track')`
- `peer.on('removestream')`
- `peer.on('removetrack')`
- `peer.on('negotiate')`

Also added the `streams` option for passing an array of MediaStreams into the constructor.

Some issues that had to be worked around:
- Firefox only being able to call pc.removeTrack when signalingState is stable.
- Neither Firefox or Safari emitting the removetrack event on MediaStreams as per spec. Had to parse remote descriptions to figure out if tracks were being removed.
- Non-initators attempting to renegotiate can lead to all sorts of race conditions. A new signal object is used to request negotiation from the initiator. This is a breaking change.
- `onnegotiationneeded` does not fire more than once in Safari, fires multiple times in Chrome and doesn't fire on removeTrack for Firefox. Removing automatic detection is actually nicer since it allows the user to make multiple asynchronous changes to the connection with a single round of negotiation. Not using the event doesn't break anything.

Thanks to @cusspvz for the initial work on this.