### PR TITLE
[WIP] Fix electron-webrtc tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,6 +271,16 @@ Peer.prototype._destroy = function (err, cb) {
   if (self._onFinishBound) self.removeListener('finish', self._onFinishBound)
   self._onFinishBound = null
 
+  if (self._channel) {
+    try {
+      self._channel.close()
+    } catch (err) {}
+
+    self._channel.onmessage = null
+    self._channel.onopen = null
+    self._channel.onclose = null
+    self._channel.onerror = null
+  }
   if (self._pc) {
     try {
       self._pc.close()
@@ -287,17 +297,6 @@ Peer.prototype._destroy = function (err, cb) {
     }
     self._pc.onnegotiationneeded = null
     self._pc.ondatachannel = null
-  }
-
-  if (self._channel) {
-    try {
-      self._channel.close()
-    } catch (err) {}
-
-    self._channel.onmessage = null
-    self._channel.onopen = null
-    self._channel.onclose = null
-    self._channel.onerror = null
   }
   self._pc = null
   self._channel = null

--- a/test/z-cleanup.js
+++ b/test/z-cleanup.js
@@ -7,7 +7,9 @@ var test = require('tape')
 test('cleanup', function (t) {
   // Shut down the electron-webrtc daemon
   if (process.env.WRTC === 'electron-webrtc') {
-    common.wrtc.close()
+    try {
+      common.wrtc.close()
+    } catch (e) {}
   }
   t.end()
 })


### PR DESCRIPTION
The `onclose` event was not being fired, so two of the tests in the stream suite were failing on electron-webrtc. Oddly enough, I could only reproduce this inside Travis.

Closing the channel before closing the pc seems to make this error disappear. I haven't seen in it the 5 runs since, where I was hitting it every time before.

I think we should figure out why electron-webrtc has this behaviour, but I'm at a loss at how to reproduce outside of Travis.