### PR TITLE
Always return an object in `signal` event

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,9 +334,9 @@ Peer.prototype.negotiate = function () {
     }
   } else {
     self._debug('requesting negotiation from initiator')
-    self.emit('signal', JSON.stringify({ // request initiator to renegotiate
+    self.emit('signal', { // request initiator to renegotiate
       renegotiate: true
-    }))
+    })
   }
   self._isNegotiating = true
 }


### PR DESCRIPTION
Every other instance of `signal` even emits an object, but this single place for some reason emits JSON string. Let's be consistent.