### PR TITLE
Remove MSID correlation test

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,6 @@ function Peer (opts) {
   self.sdpTransform = opts.sdpTransform || function (sdp) { return sdp }
   self.streams = opts.streams || (opts.stream ? [opts.stream] : []) // support old "stream" option
   self.trickle = opts.trickle !== undefined ? opts.trickle : true
-  self.allowRenegotiation = opts.allowRenegotiation !== undefined ? opts.allowRenegotiation : false
 
   self.destroyed = false
   self.connected = false
@@ -77,7 +76,6 @@ function Peer (opts) {
   self._isNegotiating = false // is this peer waiting for negotiation to complete?
   self._batchedNegotiation = false // batch synchronous negotiations
   self._queuedNegotiation = false // is there a queued negotiation request?
-  self._allowRenegotiation = opts.allowRenegotiation // Allow renegotiate signal event
   self._sendersAwaitingStable = []
   self._senderMap = new WeakMap()
 
@@ -336,11 +334,9 @@ Peer.prototype.negotiate = function () {
     }
   } else {
     self._debug('requesting negotiation from initiator')
-    if (self._allowRenegotiation) {
-      self.emit('signal', { // request initiator to renegotiate
-        renegotiate: true
-      })
-    }
+    self.emit('signal', { // request initiator to renegotiate
+      renegotiate: true
+    })
   }
   self._isNegotiating = true
 }

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ function Peer (opts) {
   self.sdpTransform = opts.sdpTransform || function (sdp) { return sdp }
   self.streams = opts.streams || (opts.stream ? [opts.stream] : []) // support old "stream" option
   self.trickle = opts.trickle !== undefined ? opts.trickle : true
+  self.allowRenegotiation = opts.allowRenegotiation !== undefined ? opts.allowRenegotiation : false
 
   self.destroyed = false
   self.connected = false
@@ -76,6 +77,7 @@ function Peer (opts) {
   self._isNegotiating = false // is this peer waiting for negotiation to complete?
   self._batchedNegotiation = false // batch synchronous negotiations
   self._queuedNegotiation = false // is there a queued negotiation request?
+  self._allowRenegotiation = opts.allowRenegotiation // Allow renegotiate signal event
   self._sendersAwaitingStable = []
   self._senderMap = new WeakMap()
 
@@ -334,9 +336,11 @@ Peer.prototype.negotiate = function () {
     }
   } else {
     self._debug('requesting negotiation from initiator')
-    self.emit('signal', { // request initiator to renegotiate
-      renegotiate: true
-    })
+    if (self._allowRenegotiation) {
+      self.emit('signal', { // request initiator to renegotiate
+        renegotiate: true
+      })
+    }
   }
   self._isNegotiating = true
 }

--- a/test/multistream.js
+++ b/test/multistream.js
@@ -1,7 +1,6 @@
 var common = require('./common')
 var Peer = require('../')
 var test = require('tape')
-var bowser = require('bowser')
 
 var config
 test('get config', function (t) {

--- a/test/multistream.js
+++ b/test/multistream.js
@@ -124,7 +124,7 @@ test('track and stream ids are correct', function (t) {
     t.end()
     return
   }
-  if (bowser.safari || bowser.ios) {
+  if (bowser.safari || bowser.ios || bowser.firefox) {
     // Note: WebKit bug filed here: https://bugs.webkit.org/show_bug.cgi?id=174519
     t.pass('Skipping test, track ids are randomized in Safari')
     t.end()

--- a/test/multistream.js
+++ b/test/multistream.js
@@ -118,52 +118,6 @@ test('incremental multistream', function (t) {
   })
 })
 
-test('track and stream ids are correct', function (t) {
-  if (common.wrtc) {
-    t.pass('Skipping test, no MediaStream support on wrtc')
-    t.end()
-    return
-  }
-  if (bowser.safari || bowser.ios || bowser.firefox) {
-    // Note: WebKit bug filed here: https://bugs.webkit.org/show_bug.cgi?id=174519
-    t.pass('Skipping test, track ids are randomized in Safari')
-    t.end()
-    return
-  }
-  t.plan(6)
-
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
-
-  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
-  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
-
-  var stream1 = common.getMediaStream()
-  var stream2 = common.getMediaStream()
-
-  stream1.removeTrack(stream1.getTracks()[1]) // single-track mediastream
-  stream2.removeTrack(stream2.getTracks()[1])
-
-  peer1.addTrack(stream1.getTracks()[0], stream1)
-  peer2.addTrack(stream2.getTracks()[0], stream2)
-
-  peer1.on('track', function (track, stream) {
-    t.equal(track.id, stream2.getTracks()[0].id, 'track id is correct')
-    t.equal(stream.id, stream2.id, 'stream id is correct')
-  })
-  peer2.on('track', function (track, stream) {
-    t.equal(track.id, stream1.getTracks()[0].id, 'track id is correct')
-    t.equal(stream.id, stream1.id, 'stream id is correct')
-  })
-
-  peer1.on('stream', function (stream) {
-    t.equal(stream.id, stream2.id, 'stream id is correct')
-  })
-  peer2.on('stream', function (stream) {
-    t.equal(stream.id, stream1.id, 'stream id is correct')
-  })
-})
-
 test('removeTrack immediately', function (t) {
   if (common.wrtc) {
     t.pass('Skipping test, no MediaStream support on wrtc')

--- a/test/negotiation.js
+++ b/test/negotiation.js
@@ -230,7 +230,7 @@ test('renegotiation after removeTrack', function (t) {
   })
 })
 
-test('renegotiation from non-intiator', function (t) {
+test('renegotiation from non-initiator', function (t) {
   if (common.wrtc) {
     t.pass('Skipping test, no MediaStream support on wrtc')
     t.end()

--- a/test/negotiation.js
+++ b/test/negotiation.js
@@ -229,3 +229,28 @@ test('renegotiation after removeTrack', function (t) {
     t.pass('remote removetrack received')
   })
 })
+
+test('renegotiation from non-intiator', function (t) {
+  if (common.wrtc) {
+    t.pass('Skipping test, no MediaStream support on wrtc')
+    t.end()
+    return
+  }
+  t.plan(1)
+
+  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  peer2.on('connect', function () {
+    var stream = common.getMediaStream()
+    peer2.addTrack(stream.getTracks()[0], stream)
+  })
+
+  peer1.on('track', function () {
+    t.pass('remote track received')
+    t.end()
+  })
+})


### PR DESCRIPTION
Local tracks IDs do not correspond to remote track IDs in Firefox or Safari.