### PR TITLE
Buffer usage elimination #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,24 @@ module.exports = Peer
 var debug = require('debug')('simple-peer')
 var getBrowserRTC = require('get-browser-rtc')
 var inherits = require('inherits')
-var randombytes = require('randombytes')
+var randombytes = require('./lib/randombytes')
 var stream = require('readable-stream')
 
 var MAX_BUFFERED_AMOUNT = 64 * 1024
 
 inherits(Peer, stream.Duplex)
+
+/**
+ * @param {Uint8Array} array
+ * @return {string}
+ */
+function array2hex (array) {
+  var string = ''
+  for (var i = 0; i < array.length; ++i) {
+    string += array[i].toString(16).padStart(2, '0')
+  }
+  return string
+}
 
 /**
  * WebRTC peer connection. Same API as node core `net.Socket`, plus a few extra methods.
@@ -19,7 +31,7 @@ function Peer (opts) {
   var self = this
   if (!(self instanceof Peer)) return new Peer(opts)
 
-  self._id = randombytes(4).toString('hex').slice(0, 7)
+  self._id = array2hex(randombytes(4)).slice(0, 7)
   self._debug('new peer %o', opts)
 
   opts = Object.assign({
@@ -29,7 +41,7 @@ function Peer (opts) {
   stream.Duplex.call(self, opts)
 
   self.channelName = opts.initiator
-    ? opts.channelName || randombytes(20).toString('hex')
+    ? opts.channelName || array2hex(randombytes(20))
     : null
 
   // Needed by _transformConstraints, so set this early

--- a/index.js
+++ b/index.js
@@ -811,7 +811,7 @@ Peer.prototype._onChannelMessage = function (event) {
   var self = this
   if (self.destroyed) return
   var data = event.data
-  if (data instanceof ArrayBuffer) data = Buffer.from(data)
+  if (data instanceof ArrayBuffer) data = new Uint8Array(data)
   self.push(data)
 }
 

--- a/lib/randombytes.browser.js
+++ b/lib/randombytes.browser.js
@@ -1,0 +1,5 @@
+module.exports = function (size) {
+  var array = new Uint8Array(size)
+  window.crypto.getRandomValues(array)
+  return array
+}

--- a/lib/randombytes.js
+++ b/lib/randombytes.js
@@ -1,0 +1,1 @@
+module.exports = require('crypto').randomBytes

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "debug": "^3.1.0",
     "get-browser-rtc": "^1.0.0",
     "inherits": "^2.0.1",
-    "randombytes": "^2.0.3",
     "readable-stream": "^2.3.4"
   },
   "devDependencies": {
@@ -50,6 +49,9 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "browser": {
+    "./lib/randombytes": "./lib/randombytes.browser"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/feross/simple-peer.git"

--- a/test/object-mode.js
+++ b/test/object-mode.js
@@ -66,12 +66,12 @@ test('data send/receive Buffer {objectMode: true}', function (t) {
 
     peer1.send(Buffer.from('this is a Buffer'))
     peer2.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is a Buffer')
+      t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
       t.deepEqual(data, Buffer.from('this is a Buffer'), 'got correct message')
 
       peer2.send(Buffer.from('this is another Buffer'))
       peer1.on('data', function (data) {
-        t.ok(Buffer.isBuffer(data), 'data is a Buffer')
+        t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
         t.deepEqual(data, Buffer.from('this is another Buffer'), 'got correct message')
 
         peer1.on('close', function () { t.pass('peer1 destroyed') })
@@ -102,14 +102,14 @@ test('data send/receive Uint8Array {objectMode: true}', function (t) {
 
     peer1.send(new Uint8Array([0, 1, 2]))
     peer2.on('data', function (data) {
-      // binary types always get converted to Buffer
+      // binary types always get converted to Uint8Array
       // See: https://github.com/feross/simple-peer/issues/138#issuecomment-278240571
-      t.ok(Buffer.isBuffer(data), 'data is a Buffer')
+      t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
       t.deepEqual(data, Buffer.from([0, 1, 2]), 'got correct message')
 
       peer2.send(new Uint8Array([1, 2, 3]))
       peer1.on('data', function (data) {
-        t.ok(Buffer.isBuffer(data), 'data is a Buffer')
+        t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
         t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct message')
 
         peer1.on('close', function () { t.pass('peer1 destroyed') })
@@ -140,12 +140,12 @@ test('data send/receive ArrayBuffer {objectMode: true}', function (t) {
 
     peer1.send(new Uint8Array([0, 1, 2]).buffer)
     peer2.on('data', function (data) {
-      t.ok(Buffer.isBuffer(data), 'data is a Buffer')
+      t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
       t.deepEqual(data, Buffer.from([0, 1, 2]), 'got correct message')
 
       peer2.send(new Uint8Array([1, 2, 3]).buffer)
       peer1.on('data', function (data) {
-        t.ok(Buffer.isBuffer(data), 'data is a Buffer')
+        t.ok(data instanceof Uint8Array, 'data is a Uint8Array')
         t.deepEqual(data, Buffer.from([1, 2, 3]), 'got correct message')
 
         peer1.on('close', function () { t.pass('peer1 destroyed') })


### PR DESCRIPTION
This is the first step in reducing bundle size as discussed in #280

This PR removes explicit usage of Buffer API in simple-peer itself, but Buffer is still used by `debug` and `readable-stream`, so bundle size will not be much smaller just yet, those will be tacked in a separate PR.

One major implication of this PR is that `data` event will dispatch with `Uint8Array` instead of `Buffer`, which is a major breaking change.

I believe this is a reasonable trade-off since It is easy to upgrade existing code base with `Buffer.from(data)`, while browser users that don't need Buffer API will have significantly less code to download.