### PR TITLE
Update docs to reflect actual STUN URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If `opts` is specified, then the default options (shown below) will be overridde
   initiator: false,
   channelConfig: {},
   channelName: '<random string>',
-  config: { iceServers: [ { urls: 'stun:stun.l.google.com:19302' } ] },
+  config: { iceServers: [ { urls: 'stun:23.21.150.121' } ] },
   constraints: {},
   offerConstraints: {},
   answerConstraints: {},


### PR DESCRIPTION
Just noticed this was out of date.