### PR TITLE
Do not fire renegotiation request on first transition to stable

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ function Peer (opts) {
   self._queuedNegotiation = false // is there a queued negotiation request?
   self._sendersAwaitingStable = []
   self._senderMap = new WeakMap()
+  self._firstStable = true
 
   self._remoteTracks = []
   self._remoteStreams = []
@@ -770,7 +771,7 @@ Peer.prototype._onSignalingStateChange = function () {
   var self = this
   if (self.destroyed) return
 
-  if (self._pc.signalingState === 'stable') {
+  if (self._pc.signalingState === 'stable' && !self._firstStable) {
     self._isNegotiating = false
 
     // HACK: Firefox doesn't yet support removing tracks when signalingState !== 'stable'
@@ -790,6 +791,7 @@ Peer.prototype._onSignalingStateChange = function () {
     self._debug('negotiate')
     self.emit('negotiate')
   }
+  self._firstStable = false
 
   self._debug('signalingStateChange %s', self._pc.signalingState)
   self.emit('signalingStateChange', self._pc.signalingState)

--- a/test/basic.js
+++ b/test/basic.js
@@ -68,7 +68,7 @@ test('signal event does not get emitted by non-initiator with stream', function 
     peer.on('close', function () { t.pass('peer destroyed') })
     peer.destroy()
   })
-  
+
   setTimeout(() => {
     t.pass('did not get signal after 1000ms')
     t.end()

--- a/test/basic.js
+++ b/test/basic.js
@@ -57,6 +57,12 @@ test('signal event does not get emitted by non-initiator', function (t) {
 })
 
 test('signal event does not get emitted by non-initiator with stream', function (t) {
+  if (common.wrtc) {
+    t.pass('Skipping test, no MediaStream support on wrtc')
+    t.end()
+    return
+  }
+
   var peer = new Peer({
     config: config,
     stream: common.getMediaStream(),

--- a/test/basic.js
+++ b/test/basic.js
@@ -42,6 +42,39 @@ test('signal event gets emitted', function (t) {
   })
 })
 
+test('signal event does not get emitted by non-initiator', function (t) {
+  var peer = new Peer({ config: config, initiator: false, wrtc: common.wrtc })
+  peer.once('signal', function () {
+    t.fail('got signal event')
+    peer.on('close', function () { t.pass('peer destroyed') })
+    peer.destroy()
+  })
+
+  setTimeout(() => {
+    t.pass('did not get signal after 1000ms')
+    t.end()
+  }, 1000)
+})
+
+test('signal event does not get emitted by non-initiator with stream', function (t) {
+  var peer = new Peer({
+    config: config,
+    stream: common.getMediaStream(),
+    initiator: false,
+    wrtc: common.wrtc
+  })
+  peer.once('signal', function () {
+    t.fail('got signal event')
+    peer.on('close', function () { t.pass('peer destroyed') })
+    peer.destroy()
+  })
+  
+  setTimeout(() => {
+    t.pass('did not get signal after 1000ms')
+    t.end()
+  }, 1000)
+})
+
 test('data send/receive text', function (t) {
   t.plan(10)
 


### PR DESCRIPTION
The non-initiator sends an unnecessary renegotiation request over the signalling channel on startup.

This doesn't change any connection behaviour, but removes an unneeded signal message.

Solves #366 