### PR TITLE
Filter trickle lines when trickle is disabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ If `opts` is specified, then the default options (shown below) will be overridde
   stream: false,
   streams: [],
   trickle: true,
+  allowHalfTrickle: false,
   wrtc: {}, // RTCPeerConnection/RTCSessionDescription/RTCIceCandidate
   objectMode: false
 }

--- a/index.js
+++ b/index.js
@@ -985,7 +985,7 @@ function shimPromiseAPI (RTCPeerConnection, pc) {
 
 // HACK: Filter trickle lines when trickle is disabled #354
 function filterTrickle (sdp) {
-  return sdp.replace(new RegExp('a=ice-options:trickle\\s\\n', 'g'), '')
+  return sdp.replace(/a=ice-options:trickle\s\n/g, '')
 }
 
 function makeError (message, code) {

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function Peer (opts) {
   self.sdpTransform = opts.sdpTransform || function (sdp) { return sdp }
   self.streams = opts.streams || (opts.stream ? [opts.stream] : []) // support old "stream" option
   self.trickle = opts.trickle !== undefined ? opts.trickle : true
-  self.allowHalfTrickle = opts.allowHalfTrickle !== undefined ? opts.trickle : false
+  self.allowHalfTrickle = opts.allowHalfTrickle !== undefined ? opts.allowHalfTrickle : false
   self.iceCompleteTimeout = opts.iceCompleteTimeout || ICECOMPLETE_TIMEOUT
 
   self.destroyed = false
@@ -983,6 +983,7 @@ function shimPromiseAPI (RTCPeerConnection, pc) {
   }
 }
 
+// HACK: Filter trickle lines when trickle is disabled #354
 function filterTrickle (sdp) {
   return sdp.replace(new RegExp('a=ice-options:trickle\\s\\n', 'g'), '')
 }


### PR DESCRIPTION
Solves #354 

Announcing trickle support and then not engaging in trickle can cause browsers to throw ` ICE Connection failed`. This PR changes the default behaviour to not announce support when trickle is disabled.

Also adds and documents `allowHalfTrickle`, which disables this filtering.

This will break applications that do SDP munging and rely on the trickle lines being present. These applications will need to set `allowHalfTrickle: true` to get the old behaviour.