### PR TITLE
Add Metastream to projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ var peer2 = new Peer({ wrtc: wrtc })
 - [TalktoMe](https://talktome.space) - Skype alternative for audio/video conferencing based on WebRTC, but without the loss of packets.
 - [CDNBye](https://github.com/cdnbye/hlsjs-p2p-engine) - CDNBye implements WebRTC datachannel to scale live/vod video streaming by peer-to-peer network using bittorrent-like protocol
 - [Detox](https://github.com/Detox) - Overlay network for distributed anonymous P2P communications entirely in the browser
+- [Metastream](https://github.com/samuelmaddock/metastream) - Watch streaming media with friends.
 - *Your app here! - send a PR!*
 
 ## api


### PR DESCRIPTION
I'm using simple-peer in [Metastream](https://getmetastream.com/) to connect WebRTC peers using data channels. Super useful library, thanks for making it!