### PR TITLE
Check if peer is destroyed in async sendOffer, sendAnswer

### DIFF
--- a/index.js
+++ b/index.js
@@ -572,6 +572,7 @@ Peer.prototype._createOffer = function () {
     }
 
     function sendOffer () {
+      if (self.destroyed) return
       var signal = self._pc.localDescription || offer
       self._debug('signal')
       self.emit('signal', {
@@ -603,6 +604,7 @@ Peer.prototype._createAnswer = function () {
     }
 
     function sendAnswer () {
+      if (self.destroyed) return
       var signal = self._pc.localDescription || answer
       self._debug('signal')
       self.emit('signal', {


### PR DESCRIPTION
Solves a race condition when the peer is destroyed before the createOffer promise resolves, which was throwing an uncaught error.

Fixes #397