### PR TITLE
Fix tests in PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,8 @@ env:
     - CXX=g++-4.8
     - secure: LqHyGcEyVXqymrZ77atyvoTthiE9ehXaxHjqLWFpIGNBdGBlASJNG42lhTR8YsM2MiIbzhslxLudyy2r4IljwbRV3/AB1mEf8J3lu1S3v5L/P1a6OeJOQWR3Nl50Z518rRFUermFlSjsdDEZp/i/o+KRz6VNAgwS31j6fvV8tdw=
     - secure: jEGOmkQelLxLeBQnHxpJN9G/TmGLbUNY+qyzVSV2ImC+EJ1QXRv03ynHO6WxZt0RPbHcOgbY3pA8gpPKA0uQagkVHNkBneJeeqJBD9kSywJpdfhzvD42ZsEWkUAQF3T8DOuSOUS0PR2/h4QpMmFmz9wTgb4Y1QLd47oMSglnIs8=
+script:
+  - if [ -z "${SAUCE_USERNAME}" ]; 
+    then npm run test-pull-request;
+    else npm test;
+    fi

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "build": "browserify -s SimplePeer -r ./ | minify > simplepeer.min.js",
     "size": "npm run build && cat simplepeer.min.js | gzip | wc -c",
     "test": "standard && npm run test-node && npm run test-browser",
+    "test-pull-request": "standard && npm run test-node",
     "test-browser": "airtap --coverage -- test/*.js",
     "test-browser-local": "airtap --coverage --local -- test/*.js",
     "test-node": "npm run test-node-electron-webrtc && npm run test-node-wrtc",


### PR DESCRIPTION
This changes the Travis script to skip Airtap browser tests in PRs (since they always fail due to missing credentials).

Saves us the time of checking for a real build failure vs just missing credentials.
