### PR TITLE
Use default iceServers when none are specified in a config object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,7 @@ function Peer (opts) {
 
   self.initiator = opts.initiator || false
   self.channelConfig = opts.channelConfig || Peer.channelConfig
-  self.config = opts.config || Peer.config
-  self.config.iceServers = self.config.iceServers || Peer.config.iceServers
+  self.config = Object.assign({}, Peer.config, opts.config)
   self.constraints = self._transformConstraints(opts.constraints || Peer.constraints)
   self.offerConstraints = self._transformConstraints(opts.offerConstraints || {})
   self.answerConstraints = self._transformConstraints(opts.answerConstraints || {})

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ function Peer (opts) {
   self.initiator = opts.initiator || false
   self.channelConfig = opts.channelConfig || Peer.channelConfig
   self.config = opts.config || Peer.config
+  self.config.iceServers = self.config.iceServers || Peer.config.iceServers
   self.constraints = self._transformConstraints(opts.constraints || Peer.constraints)
   self.offerConstraints = self._transformConstraints(opts.offerConstraints || {})
   self.answerConstraints = self._transformConstraints(opts.answerConstraints || {})


### PR DESCRIPTION
If custom `config` objects have no `iceServers` option, the default `Peer.config.iceServers` should be used.

Should reduce ICE failures caused by incomplete config objects.