### PR TITLE
handle legacy reportstats

### DIFF
--- a/index.js
+++ b/index.js
@@ -654,7 +654,7 @@ Peer.prototype.getStats = function (cb) {
     self._pc.getStats().then(function (res) {
       var reports = []
       res.forEach(function (report) {
-        reports.push(report)
+        reports.push(flattenValues(report))
       })
       cb(null, reports)
     }, function (err) { cb(err) })
@@ -664,7 +664,7 @@ Peer.prototype.getStats = function (cb) {
     self._pc.getStats(null, function (res) {
       var reports = []
       res.forEach(function (report) {
-        reports.push(report)
+        reports.push(flattenValues(report))
       })
       cb(null, reports)
     }, function (err) { cb(err) })
@@ -684,7 +684,7 @@ Peer.prototype.getStats = function (cb) {
         report.id = result.id
         report.type = result.type
         report.timestamp = result.timestamp
-        reports.push(report)
+        reports.push(flattenValues(report))
       })
       cb(null, reports)
     }, function (err) { cb(err) })
@@ -693,6 +693,16 @@ Peer.prototype.getStats = function (cb) {
   // getStats() they implement.
   } else {
     cb(null, [])
+  }
+
+  // statreports can come with a value array instead of properties
+  function flattenValues (report) {
+    if (Object.prototype.toString.call(report.values) === '[object Array]') {
+      report.values.forEach(function (value) {
+        Object.assign(report, value)
+      })
+    }
+    return report
   }
 }
 

--- a/test/stream.js
+++ b/test/stream.js
@@ -89,7 +89,7 @@ test('duplex stream: send data one-way', function (t) {
 })
 
 test('backpressure (large files)', function (t) {
-  t.plan(19)
+  t.plan(109)
 
   var MAX_BUFFERED_AMOUNT = 64 * 1024
   var largeMessage = new Array(Math.floor(MAX_BUFFERED_AMOUNT)).fill(0).map(x => 'a').join('')
@@ -119,8 +119,8 @@ test('backpressure (large files)', function (t) {
     var count = 0
     peer2.on('data', function (chunk) {
       count++
-      t.equal(chunk.toString(), largeMessage, 'got correct message' + count + '/' + 10)
-      if (count === 10) {
+      t.equal(chunk.toString(), largeMessage, 'got correct message' + count + '/' + 100)
+      if (count === 100) {
         peer1.destroy()
         peer2.destroy()
       }
@@ -140,7 +140,7 @@ test('backpressure (large files)', function (t) {
       Peer.prototype._onChannelBufferedAmountLow.call(peer1)
     }
 
-    for (var i = 0; i < 10; i++) {
+    for (var i = 0; i < 100; i++) {
       peer1.write(largeMessage)
     }
   }


### PR DESCRIPTION
This PR fixes #221 which unfortunately is still a thing. I know the real fix should be made in react-native-webrtc, but since this isn't happening, and `getStats()` already handles other legacy cases, and this is a minor change, I thought I'll give it a try here.