### PR TITLE
Add white-space: normal to example style

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Let's create an html page that lets you manually connect two peers:
       #outgoing {
         width: 600px;
         word-wrap: break-word;
+        white-space: normal;
       }
     </style>
     <form>


### PR DESCRIPTION
Without this, `#outgoing` is just a single line for me in latest Firefox and Chromium.