### PR TITLE
Call destroy on nextTick so instantiator can bind event listeners.

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,8 @@ function Peer (opts) {
   try {
     self._pc = new (self._wrtc.RTCPeerConnection)(self.config)
   } catch (err) {
-    self.destroy(err)
+    process.nextTick(() => self.destroy(err))
+    return
   }
 
   // We prefer feature detection whenever possible, but sometimes that's not

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function Peer (opts) {
   try {
     self._pc = new (self._wrtc.RTCPeerConnection)(self.config)
   } catch (err) {
-    process.nextTick(() => self.destroy(err))
+    setTimeout(() => self.destroy(err), 0)
     return
   }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -30,6 +30,16 @@ test('create peer without options', function (t) {
   }
 })
 
+test('can detect error when RTCPeerConstructor throws', function (t) {
+  t.plan(1)
+
+  var peer = new Peer({ wrtc: { RTCPeerConnection: null } })
+  peer.once('error', function () {
+    t.pass('got error event')
+    peer.destroy()
+  })
+})
+
 test('signal event gets emitted', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
When instantiating an RTCPeerConnection throws an error, destroy the simple-peer instance on next tick so that the instantiator (in this case the `websocket-tracker.js` module inside `bittorrent-tracker`) can bind events. This way the error is caught instead of flooding the console with errors, since if an eventemitter emits an `error` event with no listeners, the error is thrown.

Current behavior inside `bittorrent-tracker/lib/client/websocket-tracker.js`:

```javascript
_createPeer (opts) {
     // ... 

    const peer = new Peer(opts) // emits 'error' event inside constructor

    peer.once('error', onError) // Too late to bind event listener
    peer.once('connect', onConnect)

    return peer

    // ... 
  }
```