### PR TITLE
Fix tests on SauceLabs iOS emulator

### DIFF
--- a/test/multistream.js
+++ b/test/multistream.js
@@ -12,6 +12,11 @@ test('get config', function (t) {
 })
 
 test('multistream', function (t) {
+  if (common.isBrowser('ios')) {
+    t.pass('Skip on iOS emulator which does not support this reliably') // iOS emulator issue #486
+    t.end()
+    return
+  }
   t.plan(20)
 
   var peer1 = new Peer({
@@ -45,6 +50,49 @@ test('multistream', function (t) {
       t.fail('received one unique stream per event')
     } else {
       receivedIds[stream.id] = true
+    }
+  })
+
+  t.on('end', () => {
+    peer1.destroy()
+    peer2.destroy()
+  })
+})
+
+test('multistream (track event)', function (t) {
+  t.plan(20)
+
+  var peer1 = new Peer({
+    config: config,
+    initiator: true,
+    wrtc: common.wrtc,
+    streams: (new Array(5)).fill(null).map(function () { return common.getMediaStream() })
+  })
+  var peer2 = new Peer({
+    config: config,
+    wrtc: common.wrtc,
+    streams: (new Array(5)).fill(null).map(function () { return common.getMediaStream() })
+  })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  var receivedIds = {}
+
+  peer1.on('track', function (track) {
+    t.pass('peer1 got track')
+    if (receivedIds[track.id]) {
+      t.fail('received one unique track per event')
+    } else {
+      receivedIds[track.id] = true
+    }
+  })
+  peer2.on('track', function (track) {
+    t.pass('peer2 got track')
+    if (receivedIds[track.id]) {
+      t.fail('received one unique track per event')
+    } else {
+      receivedIds[track.id] = true
     }
   })
 
@@ -135,6 +183,11 @@ test('delayed stream on non-initiator', function (t) {
 })
 
 test('incremental multistream', function (t) {
+  if (common.isBrowser('ios')) {
+    t.pass('Skip on iOS emulator which does not support this reliably') // iOS emulator issue #486
+    t.end()
+    return
+  }
   t.plan(12)
 
   var peer1 = new Peer({
@@ -197,7 +250,75 @@ test('incremental multistream', function (t) {
   })
 })
 
+test('incremental multistream (track event)', function (t) {
+  t.plan(22)
+
+  var peer1 = new Peer({
+    config: config,
+    initiator: true,
+    wrtc: common.wrtc,
+    streams: []
+  })
+  var peer2 = new Peer({
+    config: config,
+    wrtc: common.wrtc,
+    streams: []
+  })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  peer1.on('connect', function () {
+    t.pass('peer1 connected')
+    peer1.addStream(common.getMediaStream())
+  })
+  peer2.on('connect', function () {
+    t.pass('peer2 connected')
+    peer2.addStream(common.getMediaStream())
+  })
+
+  var receivedIds = {}
+
+  var count1 = 0
+  peer1.on('track', function (track) {
+    t.pass('peer1 got track')
+    if (receivedIds[track.id]) {
+      t.fail('received one unique track per event')
+    } else {
+      receivedIds[track.id] = true
+    }
+    count1++
+    if (count1 % 2 === 0 && count1 < 10) {
+      peer1.addStream(common.getMediaStream())
+    }
+  })
+
+  var count2 = 0
+  peer2.on('track', function (track) {
+    t.pass('peer2 got track')
+    if (receivedIds[track.id]) {
+      t.fail('received one unique track per event')
+    } else {
+      receivedIds[track.id] = true
+    }
+    count2++
+    if (count2 % 2 === 0 && count2 < 10) {
+      peer2.addStream(common.getMediaStream())
+    }
+  })
+
+  t.on('end', () => {
+    peer1.destroy()
+    peer2.destroy()
+  })
+})
+
 test('incremental multistream on non-initiator only', function (t) {
+  if (common.isBrowser('ios')) {
+    t.pass('Skip on iOS emulator which does not support this reliably') // iOS emulator issue #486
+    t.end()
+    return
+  }
   t.plan(7)
 
   var peer1 = new Peer({
@@ -235,6 +356,54 @@ test('incremental multistream on non-initiator only', function (t) {
     }
     count++
     if (count < 5) {
+      peer2.addStream(common.getMediaStream())
+    }
+  })
+
+  t.on('end', () => {
+    peer1.destroy()
+    peer2.destroy()
+  })
+})
+
+test('incremental multistream on non-initiator only (track event)', function (t) {
+  t.plan(12)
+
+  var peer1 = new Peer({
+    config: config,
+    initiator: true,
+    wrtc: common.wrtc,
+    streams: []
+  })
+  var peer2 = new Peer({
+    config: config,
+    wrtc: common.wrtc,
+    streams: []
+  })
+
+  peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
+  peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
+
+  peer1.on('connect', function () {
+    t.pass('peer1 connected')
+  })
+  peer2.on('connect', function () {
+    t.pass('peer2 connected')
+    peer2.addStream(common.getMediaStream())
+  })
+
+  var receivedIds = {}
+
+  var count = 0
+  peer1.on('track', function (track) {
+    t.pass('peer1 got track')
+    if (receivedIds[track.id]) {
+      t.fail('received one unique track per event')
+    } else {
+      receivedIds[track.id] = true
+    }
+    count++
+    if (count % 2 === 0 && count < 10) {
       peer2.addStream(common.getMediaStream())
     }
   })


### PR DESCRIPTION
Resolves #486.

WebRTC in Safari on the SauceLabs iOS emulator displays an issue that doesn't exist in the XCode iOS simulator or on real iPhones. We correlate remote tracks by comparing the ID of the stream in the track event. This ID is meant to be the same for tracks attached to the same stream, but sometimes the stream gets a unique ID per track on this emulator.

To fix the tests, this PR disables multistream tests on iOS and adds new tests using the working `track` event (so we are still testing multistreaming on iOS).