### PR TITLE
Renable Safari multi-streaming tests

### DIFF
--- a/test/multistream.js
+++ b/test/multistream.js
@@ -144,8 +144,8 @@ test('multistream on non-initiator only', function (t) {
 })
 
 test('delayed stream on non-initiator', function (t) {
-  if (common.isBrowser('safari') || common.isBrowser('ios')) {
-    t.pass('Skip on Safari and iOS which do not support this reliably') // TODO: Enable in Safari 12.2
+  if (common.isBrowser('ios')) {
+    t.pass('Skip on iOS which does not support this reliably') 
     t.end()
     return
   }
@@ -415,8 +415,8 @@ test('incremental multistream on non-initiator only (track event)', function (t)
 })
 
 test('addStream after removeStream', function (t) {
-  if (common.isBrowser('safari') || common.isBrowser('ios')) {
-    t.pass('Skip on Safari and iOS which do not support this reliably') // TODO: Enable in Safari 12.2
+  if (common.isBrowser('ios')) {
+    t.pass('Skip on iOS which does not support this reliably')
     t.end()
     return
   }

--- a/test/multistream.js
+++ b/test/multistream.js
@@ -145,7 +145,7 @@ test('multistream on non-initiator only', function (t) {
 
 test('delayed stream on non-initiator', function (t) {
   if (common.isBrowser('ios')) {
-    t.pass('Skip on iOS which does not support this reliably') 
+    t.pass('Skip on iOS which does not support this reliably')
     t.end()
     return
   }

--- a/test/negotiation.js
+++ b/test/negotiation.js
@@ -110,8 +110,8 @@ test('repeated manual renegotiation', function (t) {
 })
 
 test('renegotiation after addStream', function (t) {
-  if (common.isBrowser('safari') || common.isBrowser('ios')) {
-    t.pass('Skip on Safari and iOS which do not support this reliably') // TODO: Enable in Safari 12.2
+  if (common.isBrowser('ios')) {
+    t.pass('Skip on iOS which does not support this reliably')
     t.end()
     return
   }


### PR DESCRIPTION
These tests now pass as of Safari 12.2.

They still fail on the Saucelabs iOS emulator, but pass on real iPhones. (Same stream ID issue as before.) 
