### PR TITLE
Use queueMicrotask instead of setTimeout(fn, 0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "debug": "^4.0.1",
     "get-browser-rtc": "^1.0.0",
+    "queue-microtask": "^1.1.0",
     "randombytes": "^2.0.3",
     "readable-stream": "^3.4.0"
   },


### PR DESCRIPTION
Modern browsers throttle timers severely, so setTimeout(…, 0) usually takes at least 4ms to run. Furthermore, the throttling gets even worse if the page is backgrounded.

queueMicrotask has none of these problems. But it's not available in Node 10 or earlier, and very old browsers. [`queue-microtask`](https://github.com/feross/queue-microtask) provides a no dependency, 6 line fallback for these environments.

Eventually, we can remove the package when we don't support Node 10 anymore.