### PR TITLE
Add remote ICE candidates even when no local description

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ class Peer extends stream.Duplex {
       this.addTransceiver(data.transceiverRequest.kind, data.transceiverRequest.init)
     }
     if (data.candidate) {
-      if (this._pc.localDescription && this._pc.localDescription.type && this._pc.remoteDescription && this._pc.remoteDescription.type) {
+      if (this._pc.remoteDescription && this._pc.remoteDescription.type) {
         this._addIceCandidate(data.candidate)
       } else {
         this._pendingCandidates.push(data.candidate)


### PR DESCRIPTION
I noticed that sometimes, peer connections faile with ICE
connection error. After investigation, it became clear that some
of the remote ICE candidates were received but not added to the
RTCPeerConnection.

In 7d06546a823f07a4719cdd68df9c1dd33d68804c the behavior for
incoming remote ICE candidates was changed to only directly
add them if both remote and local description are already set.

Since remote ICE candidates are only relevant for the remote
description, this seems to be incorrect and this change reverts
said change and queues remote ICE candidates when the remote
description is not set. Also pending ICE candidates are only
flushed after the remote description is set (and not for the
local description) so i guess this change was unintentional in
the fist place.