### PR TITLE
Avoid loosing required negotiation when not the initiator

### DIFF
--- a/index.js
+++ b/index.js
@@ -382,7 +382,10 @@ class Peer extends stream.Duplex {
         }, 0)
       }
     } else {
-      if (!this._isNegotiating) {
+      if (this._isNegotiating) {
+        this._queuedNegotiation = true
+        this._debug('already negotiating, queueing')
+      } else {
         this._debug('requesting negotiation from initiator')
         this.emit('signal', { // request initiator to renegotiate
           renegotiate: true


### PR DESCRIPTION
I noticed that sometimes a newly added track is not transmitted to the
remote peer. This happend when the track is added while the connection
is not yet stable and when the local peer is not the initiator.

It turned out that for this scenario, the negotiation is missed when due
to timing, the track is added while the local peer already created the
local answer but the signaling state is not yet stable.

A peer which is not the initiator might require negotiation while an
existingnegotiation is not yet complete. This change ensures that a new
negotiation is queued when one is already in progress even when the
local peer is not the initiator.

This can lead to double negotiation if timing is unlucky. To avoid that,
ensure to add tracks before the first local offer is created.