### PR TITLE
Use object shorthand for properties

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -43,7 +43,7 @@ test('can detect error when RTCPeerConstructor throws', function (t) {
 test('signal event gets emitted', function (t) {
   t.plan(2)
 
-  var peer = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
+  var peer = new Peer({ config, initiator: true, wrtc: common.wrtc })
   peer.once('signal', function () {
     t.pass('got signal event')
     peer.on('close', function () { t.pass('peer destroyed') })
@@ -52,7 +52,7 @@ test('signal event gets emitted', function (t) {
 })
 
 test('signal event does not get emitted by non-initiator', function (t) {
-  var peer = new Peer({ config: config, initiator: false, wrtc: common.wrtc })
+  var peer = new Peer({ config, initiator: false, wrtc: common.wrtc })
   peer.once('signal', function () {
     t.fail('got signal event')
     peer.on('close', function () { t.pass('peer destroyed') })
@@ -67,7 +67,7 @@ test('signal event does not get emitted by non-initiator', function (t) {
 
 test('signal event does not get emitted by non-initiator with stream', function (t) {
   var peer = new Peer({
-    config: config,
+    config,
     stream: common.getMediaStream(),
     initiator: false,
     wrtc: common.wrtc
@@ -87,8 +87,8 @@ test('signal event does not get emitted by non-initiator with stream', function 
 test('data send/receive text', function (t) {
   t.plan(10)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
 
   var numSignal1 = 0
   peer1.on('signal', function (data) {
@@ -135,8 +135,8 @@ test('data send/receive text', function (t) {
 test('sdpTransform function is called', function (t) {
   t.plan(3)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, sdpTransform: sdpTransform, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, sdpTransform, wrtc: common.wrtc })
 
   function sdpTransform (sdp) {
     t.equal(typeof sdp, 'string', 'got a string as SDP')
@@ -168,8 +168,8 @@ test('old constraint formats are used', function (t) {
     }
   }
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc, constraints: constraints })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc, constraints: constraints })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc, constraints })
+  var peer2 = new Peer({ config, wrtc: common.wrtc, constraints })
 
   peer1.on('signal', function (data) {
     peer2.signal(data)
@@ -196,8 +196,8 @@ test('new constraint formats are used', function (t) {
     offerToReceiveVideo: true
   }
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc, constraints: constraints })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc, constraints: constraints })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc, constraints })
+  var peer2 = new Peer({ config, wrtc: common.wrtc, constraints })
 
   peer1.on('signal', function (data) {
     peer2.signal(data)
@@ -230,8 +230,8 @@ test('ensure remote address and port are available right after connection', func
 
   t.plan(7)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
 
   peer1.on('signal', function (data) {
     peer2.signal(data)

--- a/test/binary.js
+++ b/test/binary.js
@@ -14,8 +14,8 @@ test('get config', function (t) {
 test('data send/receive Buffer', function (t) {
   t.plan(6)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
   peer1.on('signal', function (data) {
     peer2.signal(data)
   })
@@ -50,8 +50,8 @@ test('data send/receive Buffer', function (t) {
 test('data send/receive Uint8Array', function (t) {
   t.plan(6)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
   peer1.on('signal', function (data) {
     peer2.signal(data)
   })
@@ -88,8 +88,8 @@ test('data send/receive Uint8Array', function (t) {
 test('data send/receive ArrayBuffer', function (t) {
   t.plan(6)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
   peer1.on('signal', function (data) {
     peer2.signal(data)
   })

--- a/test/multistream.js
+++ b/test/multistream.js
@@ -20,13 +20,13 @@ test('multistream', function (t) {
   t.plan(20)
 
   var peer1 = new Peer({
-    config: config,
+    config,
     initiator: true,
     wrtc: common.wrtc,
     streams: (new Array(10)).fill(null).map(function () { return common.getMediaStream() })
   })
   var peer2 = new Peer({
-    config: config,
+    config,
     wrtc: common.wrtc,
     streams: (new Array(10)).fill(null).map(function () { return common.getMediaStream() })
   })
@@ -63,13 +63,13 @@ test('multistream (track event)', function (t) {
   t.plan(20)
 
   var peer1 = new Peer({
-    config: config,
+    config,
     initiator: true,
     wrtc: common.wrtc,
     streams: (new Array(5)).fill(null).map(function () { return common.getMediaStream() })
   })
   var peer2 = new Peer({
-    config: config,
+    config,
     wrtc: common.wrtc,
     streams: (new Array(5)).fill(null).map(function () { return common.getMediaStream() })
   })
@@ -106,13 +106,13 @@ test('multistream on non-initiator only', function (t) {
   t.plan(30)
 
   var peer1 = new Peer({
-    config: config,
+    config,
     initiator: true,
     wrtc: common.wrtc,
     streams: []
   })
   var peer2 = new Peer({
-    config: config,
+    config,
     wrtc: common.wrtc,
     streams: (new Array(10)).fill(null).map(function () { return common.getMediaStream() })
   })
@@ -153,14 +153,14 @@ test('delayed stream on non-initiator', function (t) {
   t.plan(1)
 
   var peer1 = new Peer({
-    config: config,
+    config,
     trickle: true,
     initiator: true,
     wrtc: common.wrtc,
     streams: [common.getMediaStream()]
   })
   var peer2 = new Peer({
-    config: config,
+    config,
     trickle: true,
     wrtc: common.wrtc,
     streams: []
@@ -191,13 +191,13 @@ test('incremental multistream', function (t) {
   t.plan(12)
 
   var peer1 = new Peer({
-    config: config,
+    config,
     initiator: true,
     wrtc: common.wrtc,
     streams: []
   })
   var peer2 = new Peer({
-    config: config,
+    config,
     wrtc: common.wrtc,
     streams: []
   })
@@ -254,13 +254,13 @@ test('incremental multistream (track event)', function (t) {
   t.plan(22)
 
   var peer1 = new Peer({
-    config: config,
+    config,
     initiator: true,
     wrtc: common.wrtc,
     streams: []
   })
   var peer2 = new Peer({
-    config: config,
+    config,
     wrtc: common.wrtc,
     streams: []
   })
@@ -322,13 +322,13 @@ test('incremental multistream on non-initiator only', function (t) {
   t.plan(7)
 
   var peer1 = new Peer({
-    config: config,
+    config,
     initiator: true,
     wrtc: common.wrtc,
     streams: []
   })
   var peer2 = new Peer({
-    config: config,
+    config,
     wrtc: common.wrtc,
     streams: []
   })
@@ -370,13 +370,13 @@ test('incremental multistream on non-initiator only (track event)', function (t)
   t.plan(12)
 
   var peer1 = new Peer({
-    config: config,
+    config,
     initiator: true,
     wrtc: common.wrtc,
     streams: []
   })
   var peer2 = new Peer({
-    config: config,
+    config,
     wrtc: common.wrtc,
     streams: []
   })
@@ -425,8 +425,8 @@ test('addStream after removeStream', function (t) {
   var stream1 = common.getMediaStream()
   var stream2 = common.getMediaStream()
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc, streams: [stream1] })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc, streams: [stream1] })
 
   peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
   peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
@@ -451,8 +451,8 @@ test('addStream after removeStream', function (t) {
 test('removeTrack immediately', function (t) {
   t.plan(2)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
 
   peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
   peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
@@ -489,8 +489,8 @@ test('removeTrack immediately', function (t) {
 test('replaceTrack', function (t) {
   t.plan(4)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
 
   peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
   peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })

--- a/test/negotiation.js
+++ b/test/negotiation.js
@@ -14,8 +14,8 @@ test('get config', function (t) {
 test('single negotiation', function (t) {
   t.plan(10)
 
-  var peer1 = new Peer({ config: config, initiator: true, stream: common.getMediaStream(), wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, stream: common.getMediaStream(), wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, stream: common.getMediaStream(), wrtc: common.wrtc })
+  var peer2 = new Peer({ config, stream: common.getMediaStream(), wrtc: common.wrtc })
 
   peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
   peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
@@ -55,8 +55,8 @@ test('single negotiation', function (t) {
 test('manual renegotiation', function (t) {
   t.plan(2)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
 
   peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
   peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
@@ -76,8 +76,8 @@ test('manual renegotiation', function (t) {
 test('repeated manual renegotiation', function (t) {
   t.plan(6)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
 
   peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
   peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
@@ -117,8 +117,8 @@ test('renegotiation after addStream', function (t) {
   }
   t.plan(4)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
 
   peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
   peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
@@ -143,12 +143,12 @@ test('add stream on non-initiator only', function (t) {
   t.plan(3)
 
   var peer1 = new Peer({
-    config: config,
+    config,
     initiator: true,
     wrtc: common.wrtc
   })
   var peer2 = new Peer({
-    config: config,
+    config,
     wrtc: common.wrtc,
     stream: common.getMediaStream()
   })
@@ -171,7 +171,7 @@ test('negotiated channels', function (t) {
   t.plan(2)
 
   var peer1 = new Peer({
-    config: config,
+    config,
     initiator: true,
     wrtc: common.wrtc,
     channelConfig: {
@@ -180,7 +180,7 @@ test('negotiated channels', function (t) {
     }
   })
   var peer2 = new Peer({
-    config: config,
+    config,
     wrtc: common.wrtc,
     channelConfig: {
       id: 1,

--- a/test/object-mode.js
+++ b/test/object-mode.js
@@ -14,8 +14,8 @@ test('get config', function (t) {
 test('data send/receive string {objectMode: true}', function (t) {
   t.plan(6)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc, objectMode: true })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc, objectMode: true })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc, objectMode: true })
+  var peer2 = new Peer({ config, wrtc: common.wrtc, objectMode: true })
   peer1.on('signal', function (data) {
     peer2.signal(data)
   })
@@ -50,8 +50,8 @@ test('data send/receive string {objectMode: true}', function (t) {
 test('data send/receive Buffer {objectMode: true}', function (t) {
   t.plan(6)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc, objectMode: true })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc, objectMode: true })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc, objectMode: true })
+  var peer2 = new Peer({ config, wrtc: common.wrtc, objectMode: true })
   peer1.on('signal', function (data) {
     peer2.signal(data)
   })
@@ -86,8 +86,8 @@ test('data send/receive Buffer {objectMode: true}', function (t) {
 test('data send/receive Uint8Array {objectMode: true}', function (t) {
   t.plan(6)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc, objectMode: true })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc, objectMode: true })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc, objectMode: true })
+  var peer2 = new Peer({ config, wrtc: common.wrtc, objectMode: true })
   peer1.on('signal', function (data) {
     peer2.signal(data)
   })
@@ -124,8 +124,8 @@ test('data send/receive Uint8Array {objectMode: true}', function (t) {
 test('data send/receive ArrayBuffer {objectMode: true}', function (t) {
   t.plan(6)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc, objectMode: true })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc, objectMode: true })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc, objectMode: true })
+  var peer2 = new Peer({ config, wrtc: common.wrtc, objectMode: true })
   peer1.on('signal', function (data) {
     peer2.signal(data)
   })

--- a/test/stream.js
+++ b/test/stream.js
@@ -16,8 +16,8 @@ test('duplex stream: send data before "connect" event', function (t) {
   t.plan(9)
   t.timeoutAfter(20000)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
   peer1.on('signal', function (data) { if (!peer2.destroyed) peer2.signal(data) })
   peer2.on('signal', function (data) { if (!peer1.destroyed) peer1.signal(data) })
 
@@ -52,8 +52,8 @@ test('duplex stream: send data one-way', function (t) {
   t.plan(9)
   t.timeoutAfter(20000)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
   peer1.on('signal', function (data) { peer2.signal(data) })
   peer2.on('signal', function (data) { peer1.signal(data) })
   peer1.on('connect', tryTest)

--- a/test/trickle.js
+++ b/test/trickle.js
@@ -14,8 +14,8 @@ test('get config', function (t) {
 test('disable trickle', function (t) {
   t.plan(8)
 
-  var peer1 = new Peer({ config: config, initiator: true, trickle: false, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, trickle: false, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, trickle: false, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, trickle: false, wrtc: common.wrtc })
 
   var numSignal1 = 0
   peer1.on('signal', function (data) {
@@ -60,8 +60,8 @@ test('disable trickle', function (t) {
 test('disable trickle (only initiator)', function (t) {
   t.plan(8)
 
-  var peer1 = new Peer({ config: config, initiator: true, trickle: false, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, trickle: false, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
 
   var numSignal1 = 0
   peer1.on('signal', function (data) {
@@ -106,8 +106,8 @@ test('disable trickle (only initiator)', function (t) {
 test('disable trickle (only receiver)', function (t) {
   t.plan(8)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, trickle: false, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, trickle: false, wrtc: common.wrtc })
 
   var numSignal1 = 0
   peer1.on('signal', function (data) {
@@ -150,8 +150,8 @@ test('disable trickle (only receiver)', function (t) {
 })
 
 test('null end candidate does not throw', function (t) {
-  const peer1 = new Peer({ trickle: true, config: config, initiator: true, wrtc: common.wrtc })
-  const peer2 = new Peer({ trickle: true, config: config, wrtc: common.wrtc })
+  const peer1 = new Peer({ trickle: true, config, initiator: true, wrtc: common.wrtc })
+  const peer2 = new Peer({ trickle: true, config, wrtc: common.wrtc })
 
   // translate all falsey candidates to null
   let endCandidateSent = false
@@ -180,8 +180,8 @@ test('null end candidate does not throw', function (t) {
 })
 
 test('empty-string end candidate does not throw', function (t) {
-  var peer1 = new Peer({ trickle: true, config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ trickle: true, config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ trickle: true, config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ trickle: true, config, wrtc: common.wrtc })
 
   // translate all falsey candidates to null
   let endCandidateSent = false
@@ -210,8 +210,8 @@ test('empty-string end candidate does not throw', function (t) {
 })
 
 test('mDNS candidate does not throw', function (t) {
-  var peer1 = new Peer({ trickle: true, config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ trickle: true, config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ trickle: true, config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ trickle: true, config, wrtc: common.wrtc })
 
   peer1.on('error', () => t.fail('peer1 threw error'))
   peer2.on('error', () => t.fail('peer2 threw error'))
@@ -232,8 +232,8 @@ test('mDNS candidate does not throw', function (t) {
 test('ice candidates received before description', function (t) {
   t.plan(3)
 
-  var peer1 = new Peer({ config: config, initiator: true, wrtc: common.wrtc })
-  var peer2 = new Peer({ config: config, wrtc: common.wrtc })
+  var peer1 = new Peer({ config, initiator: true, wrtc: common.wrtc })
+  var peer2 = new Peer({ config, wrtc: common.wrtc })
 
   var signalQueue1 = []
   peer1.on('signal', function (data) {


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️ 

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This syntax is compatible with all versions of Edge & Safari that supports WebRTC, Firefox 33 (2014), and Chrome 43 (2015)