### PR TITLE
fix: add buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var debug = require('debug')('simple-peer')
 var getBrowserRTC = require('get-browser-rtc')
 var randombytes = require('randombytes')
 var stream = require('readable-stream')
+var { Buffer } = require('buffer')
 var queueMicrotask = require('queue-microtask') // TODO: remove when Node 10 is not supported
 
 var MAX_BUFFERED_AMOUNT = 64 * 1024

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/feross/simple-peer/issues"
   },
   "dependencies": {
+    "buffer": "^5.6.0",
     "debug": "^4.0.1",
     "get-browser-rtc": "^1.0.0",
     "queue-microtask": "^1.1.0",


### PR DESCRIPTION
This PR adds buffer as a dependency to avoid relying on bundlers automatic node globals injection.