### PR TITLE
Improve default STUN URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -995,10 +995,10 @@ Peer.WEBRTC_SUPPORT = !!getBrowserRTC()
 Peer.config = {
   iceServers: [
     {
-      urls: 'stun:stun.l.google.com:19302'
-    },
-    {
-      urls: 'stun:global.stun.twilio.com:3478?transport=udp'
+      urls: [
+        'stun:stun.l.google.com:19302',
+        'stun:global.stun.twilio.com:3478'
+      ]
     }
   ],
   sdpSemantics: 'unified-plan'


### PR DESCRIPTION
- Remove the ?transport=udp parameter from the twilio STUN server URL because it's non-standard (see: https://github.com/aiortc/aiortc/issues/157)

- Use a single entry for both stun servers since they're interchangable and if one works, using the other isn't necessary