### PR TITLE
fix: add code property to thrown errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "debug": "^4.0.1",
+    "err-code": "^2.0.3",
     "get-browser-rtc": "^1.0.0",
     "queue-microtask": "^1.1.0",
     "randombytes": "^2.0.3",


### PR DESCRIPTION
Instead of specifying new errors with different messages and stack traces, just override the `.code` property of thrown errors.

This is an alternative approach to https://github.com/feross/simple-peer/pull/660 - instead of obscuring the original error message & stack trace, just add the `.code` property to the thrown error.