### PR TITLE
Add CubeChat to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ var peer2 = new Peer({ wrtc: wrtc })
 - [Peer.School](https://github.com/holtwick/peer2school) - Simple virtual classroom starting from the 1st class including video chat and real time whiteboard
 - [FileFire](https://filefire.ca) - Transfer large files and folders at high speed without size limits.
 - [safeShare](https://github.com/vj-abishek/airdrop) - Transfer files easily with text and voice communication.
+- [CubeChat](https://cubechat.io) - Party in 3D 🎉
 - *Your app here! - send a PR!*
 
 ## api


### PR DESCRIPTION
CubeChat (a web app for partying in 3D; https://cubechat.io/ ) is powered by simple-peer! This commit adds CubeChat to the list of apps.

We improved the homepage with pictures, and now anyone can sign up (CubeChat is out of the invite-only phase).