### PR TITLE
Delay destroy until next microtask.

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -258,3 +258,17 @@ test('ensure remote address and port are available right after connection', func
     })
   })
 })
+
+test('ensure iceStateChange fires when connection failed', (t) => {
+  t.plan(1)
+  const peer = new Peer({ config, initiator: true, wrtc: common.wrtc })
+
+  peer.on('iceStateChange', (connectionState, gatheringState) => {
+    t.pass('got iceStateChange')
+    t.end()
+  })
+
+  // simulate concurrent iceConnectionStateChange and destroy()
+  peer.destroy()
+  peer._pc.oniceconnectionstatechange()
+})


### PR DESCRIPTION
Multiple concurrent events can fire from the RTCPeerConnection or RTCDataChannel. We expose some of these in the API (notable 'iceStateChange') but they will be lost if they are concurrent with an event that destroys the peer.

This PR delays destroying the peer object until the next microtask, allowing any other events to be emitted.

Fixes #692 and any related bugs.