### PR TITLE
3 minor changes – Add 'type', Rename 'negotiate', add debug log

### DIFF
--- a/index.js
+++ b/index.js
@@ -973,6 +973,7 @@ class Peer extends stream.Duplex {
 
       this._remoteStreams.push(eventStream)
       queueMicrotask(() => {
+        this._debug('on stream')
         this.emit('stream', eventStream) // ensure all tracks have been added
       })
     })

--- a/index.js
+++ b/index.js
@@ -254,6 +254,7 @@ class Peer extends stream.Duplex {
       }
     } else {
       this.emit('signal', { // request initiator to renegotiate
+        type: 'transceiverRequest',
         transceiverRequest: { kind, init }
       })
     }
@@ -388,6 +389,7 @@ class Peer extends stream.Duplex {
       } else {
         this._debug('requesting negotiation from initiator')
         this.emit('signal', { // request initiator to renegotiate
+          type: 'renegotiate',
           renegotiate: true
         })
       }
@@ -908,6 +910,7 @@ class Peer extends stream.Duplex {
     if (this.destroyed) return
     if (event.candidate && this.trickle) {
       this.emit('signal', {
+        type: 'candidate',
         candidate: {
           candidate: event.candidate.candidate,
           sdpMLineIndex: event.candidate.sdpMLineIndex,

--- a/index.js
+++ b/index.js
@@ -897,8 +897,8 @@ class Peer extends stream.Duplex {
         this._queuedNegotiation = false
         this._needsNegotiation() // negotiate again
       } else {
-        this._debug('negotiate')
-        this.emit('negotiate')
+        this._debug('negotiated')
+        this.emit('negotiated')
       }
     }
 

--- a/test/negotiation.js
+++ b/test/negotiation.js
@@ -70,10 +70,10 @@ test('manual renegotiation', function (t) {
   peer1.on('connect', function () {
     peer1.negotiate()
 
-    peer1.on('negotiate', function () {
+    peer1.on('negotiated', function () {
       t.pass('peer1 negotiated')
     })
-    peer2.on('negotiate', function () {
+    peer2.on('negotiated', function () {
       t.pass('peer2 negotiated')
     })
   })
@@ -91,24 +91,24 @@ test('repeated manual renegotiation', function (t) {
   peer1.once('connect', function () {
     peer1.negotiate()
   })
-  peer1.once('negotiate', function () {
+  peer1.once('negotiated', function () {
     t.pass('peer1 negotiated')
     peer1.negotiate()
-    peer1.once('negotiate', function () {
+    peer1.once('negotiated', function () {
       t.pass('peer1 negotiated again')
       peer1.negotiate()
-      peer1.once('negotiate', function () {
+      peer1.once('negotiated', function () {
         t.pass('peer1 negotiated again')
       })
     })
   })
-  peer2.once('negotiate', function () {
+  peer2.once('negotiated', function () {
     t.pass('peer2 negotiated')
     peer2.negotiate()
-    peer2.once('negotiate', function () {
+    peer2.once('negotiated', function () {
       t.pass('peer2 negotiated again')
       peer1.negotiate()
-      peer1.once('negotiate', function () {
+      peer1.once('negotiated', function () {
         t.pass('peer1 negotiated again')
       })
     })


### PR DESCRIPTION
This PR includes 3 minor changes.

- Add 'type' property to all 'signal' messages
  - Only some signaling message have 'type' properties. The others rely on the key name that is in use. Having a 'type' in all messages improves console debug logs (since I can include the type in the output).
- Rename 'negotiate' event to 'negotiated'
  - I think this name is clearer since the event happens after negotiation.
- add a debug log when 'stream' is emitted
  - This is consistent with other events we fire where we log first.