### PR TITLE
Calling `send` before the channel is open doesn't buffer data

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,7 @@ Send text/binary data to the remote peer. `data` can be any of several types: `S
 `Buffer` (see [buffer](https://github.com/feross/buffer)), `ArrayBufferView` (`Uint8Array`,
 etc.), `ArrayBuffer`, or `Blob` (in browsers that support it).
 
-Note: If this method is called before the `peer.on('connect')` event has fired, then data
-will be buffered.
+Note: If this method is called before the `peer.on('connect')` event has fired, then an exception will be thrown. Use `peer.write(data)` (which is inherited from the node.js [duplex stream](http://nodejs.org/api/stream.html) interface) if you want this data to be buffered instead.
 
 ### `peer.addStream(stream)`
 
@@ -639,7 +638,7 @@ constructor. See the API docs above.
 - [safeShare](https://github.com/vj-abishek/airdrop) - Transfer files easily with text and voice communication.
 - [CubeChat](https://cubechat.io) - Party in 3D 🎉
 - [Homely School](https://homelyschool.com) - A virtual schooling system
-- [AnyDrop](https://anydrop.io) - Cross-platform AirDrop alternative [with an Android app available at Google Play](https://play.google.com/store/apps/details?id=com.benjijanssens.anydrop) 
+- [AnyDrop](https://anydrop.io) - Cross-platform AirDrop alternative [with an Android app available at Google Play](https://play.google.com/store/apps/details?id=com.benjijanssens.anydrop)
 - [Share-Anywhere](https://share-anywhere.com/) - Cross-platform file transfer
 - [QuaranTime.io](https://quarantime.io/) - The Activity board-game in video!
 - [Trango](https://web.trango.io) - Cross-platform calling and file sharing solution.


### PR DESCRIPTION
Fixes: https://github.com/feross/simple-peer/issues/690

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Calling `send` before the channel is open doesn't buffer data

**Which issue (if any) does this pull request address?**

Fixes: https://github.com/feross/simple-peer/issues/690

**Is there anything you'd like reviewers to focus on?**
