### PR TITLE
Handle "RTCPeerConnection is gone" error on FF

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,12 @@ class Peer extends stream.Duplex {
       this._onIceCandidate(event)
     }
 
+    if (typeof this._pc.peerIdentity === 'object') {
+      this._pc.peerIdentity.catch(err => {
+        this.destroy(errCode(err, 'ERR_PC_PEER_IDENTITY'))
+      })
+    }
+
     // Other spec events, unused by this implementation:
     // - onconnectionstatechange
     // - onicecandidateerror

--- a/index.js
+++ b/index.js
@@ -124,6 +124,7 @@ class Peer extends stream.Duplex {
       this._onIceCandidate(event)
     }
 
+    // HACK: Fix for odd Firefox behavior, see: https://github.com/feross/simple-peer/pull/783
     if (typeof this._pc.peerIdentity === 'object') {
       this._pc.peerIdentity.catch(err => {
         this.destroy(errCode(err, 'ERR_PC_PEER_IDENTITY'))


### PR DESCRIPTION
Complete stacktrace:

```
Uncaught (in promise) DOMException: RTCPeerConnection is gone (did you enter Offline mode?) PeerConnection.jsm:1153:12
    _validateIdentity resource://gre/modules/media/PeerConnection.jsm:1153
```

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Catch a promise rejection if the `peerIdentity` getter exists. See https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/peerIdentity for more information.

Linked to https://github.com/Chocobozzz/PeerTube/issues/3707
