### PR TITLE
Better DataChannel error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -528,7 +528,10 @@ class Peer extends stream.Duplex {
     this._channel.onclose = () => {
       this._onChannelClose()
     }
-    this._channel.onerror = err => {
+    this._channel.onerror = event => {
+      const err = event.error instanceof Error
+        ? event.error
+        : new Error(`Datachannel error: ${event.message} ${event.filename}:${event.lineno}:${event.colno}`)
       this.destroy(errCode(err, 'ERR_DATA_CHANNEL'))
     }
 


### PR DESCRIPTION
Don't emit an RTCErrorEvent since that's not an Error. Instead, emit the actual RTCError, if it exists. Otherwise, make a new Error and emit that.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Don't emit an RTCErrorEvent since that's not an Error. Instead, emit the actual RTCError, if it exists. Otherwise, make a new Error and emit that.

**Which issue (if any) does this pull request address?**

None

**Is there anything you'd like reviewers to focus on?**

Does this work in all browsers?
