### PR TITLE
Bump airtap-sauce to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "airtap": "^4.0.3",
     "airtap-manual": "^1.0.0",
-    "airtap-sauce": "^1.1.0",
+    "airtap-sauce": "^1.1.2",
     "babel-minify": "^0.5.1",
     "bowser": "^2.11.0",
     "browserify": "^17.0.0",


### PR DESCRIPTION
What is the purpose of this pull request? (put an "X" next to item)

[ ] Documentation update
[ x] Bug fix
[ ] New feature
[ ] Other, please explain:

What changes did you make? (Give an overview)

Bump airtap-sauce to 1.1.2

Which issue (if any) does this pull request address?

Fixes issue where GitHub Actions build number was not reporting, causing status badges to be unknown (theoretical issue that simple-peer's Sauce Labs badge might be using a statically cached version as I was getting "unknown" until investigating and fixing).