### PR TITLE
Fixed read-only error on sdp update in createOffer to work with react-native-webrtc

### DIFF
--- a/index.js
+++ b/index.js
@@ -610,8 +610,8 @@ class Peer extends stream.Duplex {
     this._pc.createOffer(this.offerOptions)
       .then(offer => {
         if (this.destroyed) return
-        if (!this.trickle && !this.allowHalfTrickle) offer.sdp = filterTrickle(offer.sdp)
-        offer.sdp = this.sdpTransform(offer.sdp)
+        if (!this.trickle && !this.allowHalfTrickle) offer = new (this._wrtc.RTCSessionDescription)({ type: offer.type, sdp: filterTrickle(offer.sdp) });
+        offer = new (this._wrtc.RTCSessionDescription)({ type: offer.type, sdp: this.sdpTransform(offer.sdp) });
 
         const sendOffer = () => {
           if (this.destroyed) return


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Fixed read-only sdp in createOffer when using in react native with react-native-webrtc

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
