### PR TITLE
fix: return `this` from `destroy()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -429,6 +429,7 @@ class Peer extends stream.Duplex {
   // See: https://github.com/nodejs/readable-stream/issues/283
   destroy (err) {
     this._destroy(err, () => {})
+    return this
   }
 
   _destroy (err, cb) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

This simply returns `this` from `destroy()` - quite a minor change but which brings the implemenation of `Duplex` into line with current Node implementation.

**Which issue (if any) does this pull request address?**

For consistency with Node readable stream implementation, `destroy()` should return `this` - https://nodejs.org/api/stream.html#readabledestroyerror

**Is there anything you'd like reviewers to focus on?**

Context: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57473