### PR TITLE
ADD RxDB P2P replication to the "Who is using" section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,7 @@ constructor. See the API docs above.
 - [WebDrop.Space](https://WebDrop.Space) - Share files and messages across devices. Cross-platform, no installation alternative to AirDrop, Xender. [Source Code](https://github.com/subins2000/WebDrop)
 - [Speakrandom](https://speakrandom.com) - Voice-chat social network using simple-peer to create audio conferences!
 - [Deskreen](https://deskreen.com) - A desktop app that helps you to turn any device into a secondary screen for your computer. It uses simple-peer for sharing entire computer screen to any device with a web browser.
+- [RxDB](https://rxdb.info/replication-p2p.html) - A client-side JavaScript database that uses simple-peer to replicate the database state between client devices.
 
 
 


### PR DESCRIPTION
Hi.
I am using simple-peer to replicate the database state of client devices with the RxDB P2P replication plugin. https://rxdb.info/replication-p2p.html